### PR TITLE
Fix `AbstractFurnaceBlockEntityMixin`

### DIFF
--- a/library/item/item_content_registry/src/main/java/org/quiltmc/qsl/item/content/registry/mixin/AbstractFurnaceBlockEntityMixin.java
+++ b/library/item/item_content_registry/src/main/java/org/quiltmc/qsl/item/content/registry/mixin/AbstractFurnaceBlockEntityMixin.java
@@ -53,6 +53,11 @@ public abstract class AbstractFurnaceBlockEntityMixin {
 	@Shadow
 	int field_55574;
 
+	// Uhh... Based on the old target and what this does, I *assume* that this replaces
+	// the initial "fuelTimeMap" with quilt's registry.
+	// Possible Fix:
+	// - Change the target of this mixin or create another which targets FuelTimes.
+	// - @ModifyArg(method = "<init>", at = @At(value = "STORE", ordinal = 0)
 	@Inject(method = "createFuelTimeMap", at = @At("HEAD"), cancellable = true)
 	private static void returnCachedMap(CallbackInfoReturnable<Map<Item, Integer>> cir) {
 		if (!ItemContentRegistriesInitializer.FUEL_MAP.isEmpty()) {
@@ -60,6 +65,10 @@ public abstract class AbstractFurnaceBlockEntityMixin {
 		}
 	}
 
+	// Note: I don't remember if you need to make a separate mixin to target an inner class
+	//       but assuming the mixin is targeting `FuelTimes$Builder`
+	// Possible Fix:
+	// - Inject(method = "Lnet/minecraft/block/entity/FuelTimes$Builder;add(Lnet/minecraft/registry/tag/TagKey;I)Lnet/minecraft/block/entity/FuelTimes$Builder;", at = @At("HEAD"), cancellable = true)
 	@Inject(method = "addFuel(Ljava/util/Map;Lnet/minecraft/registry/tag/TagKey;I)V", at = @At("HEAD"), cancellable = true)
 	private static void collectInitialTags(Map<Item, Integer> fuelTimes, TagKey<Item> tag, int fuelTime, CallbackInfo ci) {
 		if (ItemContentRegistriesInitializer.shouldCollectInitialTags()) {

--- a/library/item/item_content_registry/src/main/java/org/quiltmc/qsl/item/content/registry/mixin/AbstractFurnaceBlockEntityMixin.java
+++ b/library/item/item_content_registry/src/main/java/org/quiltmc/qsl/item/content/registry/mixin/AbstractFurnaceBlockEntityMixin.java
@@ -17,65 +17,18 @@
 package org.quiltmc.qsl.item.content.registry.mixin;
 
 import net.minecraft.block.entity.AbstractFurnaceBlockEntity;
-import net.minecraft.item.Item;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.registry.HolderLookup;
-import net.minecraft.registry.tag.TagKey;
-import org.quiltmc.qsl.item.content.registry.impl.ItemContentRegistriesInitializer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
-import java.util.Map;
-
-// the target mixin class suffers from multiple unmapped keywords that fallback to intermediary
-// i suspect that's the cause of most of these issues
-
-// Note: I Couldn't get the `genSources` task to work and linkie is acting wierd.
-// I'll attempt to provide the intermediary mappings in parentheses and use QM whenever possible.
-
-// Mixin: AbstractFurnaceBlockEntityMixin
-// Target: net.minecraft.block.entity.AbstractFurnaceBlockEntityMixin
-// Kind: Accessor-like
-// What it seems to do:
-//   - Allows for reading and modifying the "fuelTimeMap"
-//   - (De)Serializes the "BurnTime" nbt field from/to Int
-// Reason for breakage:
-// Mojang refactored this code since 1.21.2 (last instance of `net.minecraft.class_2609.method_11196`)
-// Migrating it to a global registry under net.minecraft.block.entity.FuelTimes (`net.minecraft.class_9895`)
-// See also: net.minecraft.class_2609.method_11200
 
 @Mixin(AbstractFurnaceBlockEntity.class)
 public abstract class AbstractFurnaceBlockEntityMixin {
 	@Shadow
 	int field_55574;
-
-	// Uhh... Based on the old target and what this does, I *assume* that this replaces
-	// the initial "fuelTimeMap" with quilt's registry.
-	// Possible Fix:
-	// - Change the target of this mixin or create another which targets FuelTimes.
-	// - @ModifyArg(method = "<init>", at = @At(value = "STORE", ordinal = 0)
-	@Inject(method = "createFuelTimeMap", at = @At("HEAD"), cancellable = true)
-	private static void returnCachedMap(CallbackInfoReturnable<Map<Item, Integer>> cir) {
-		if (!ItemContentRegistriesInitializer.FUEL_MAP.isEmpty()) {
-			cir.setReturnValue(ItemContentRegistriesInitializer.FUEL_MAP);
-		}
-	}
-
-	// Note: I don't remember if you need to make a separate mixin to target an inner class
-	//       but assuming the mixin is targeting `FuelTimes$Builder`
-	// Possible Fix:
-	// - Inject(method = "Lnet/minecraft/block/entity/FuelTimes$Builder;add(Lnet/minecraft/registry/tag/TagKey;I)Lnet/minecraft/block/entity/FuelTimes$Builder;", at = @At("HEAD"), cancellable = true)
-	@Inject(method = "addFuel(Ljava/util/Map;Lnet/minecraft/registry/tag/TagKey;I)V", at = @At("HEAD"), cancellable = true)
-	private static void collectInitialTags(Map<Item, Integer> fuelTimes, TagKey<Item> tag, int fuelTime, CallbackInfo ci) {
-		if (ItemContentRegistriesInitializer.shouldCollectInitialTags()) {
-			ItemContentRegistriesInitializer.INITIAL_FUEL_TAG_MAP.put(tag, fuelTime);
-			ci.cancel();
-		}
-	}
 
 	// Serializes burn time as an integer instead of a short.
 	// Should not cause any desyncs as BE sync packets are now NBT.

--- a/library/item/item_content_registry/src/main/java/org/quiltmc/qsl/item/content/registry/mixin/AbstractFurnaceBlockEntityMixin.java
+++ b/library/item/item_content_registry/src/main/java/org/quiltmc/qsl/item/content/registry/mixin/AbstractFurnaceBlockEntityMixin.java
@@ -82,11 +82,11 @@ public abstract class AbstractFurnaceBlockEntityMixin {
 
 	@Inject(method = "readNbtImpl", at = @At("TAIL"))
 	private void readBurnTimeAsInt(NbtCompound nbt, HolderLookup.Provider lookupProvider, CallbackInfo info) {
-		this.field_55574 = nbt.getInt("BurnTime");
+		this.field_55574 = nbt.getInt("lit_time_remaining");
 	}
 
 	@Inject(method = "writeNbt", at = @At("TAIL"))
 	private void writeBurnTimeAsInt(NbtCompound nbt, HolderLookup.Provider lookupProvider, CallbackInfo info) {
-		nbt.putInt("BurnTime", this.field_55574);
+		nbt.putInt("lit_time_remaining", this.field_55574);
 	}
 }

--- a/library/item/item_content_registry/src/main/java/org/quiltmc/qsl/item/content/registry/mixin/AbstractFurnaceBlockEntityMixin.java
+++ b/library/item/item_content_registry/src/main/java/org/quiltmc/qsl/item/content/registry/mixin/AbstractFurnaceBlockEntityMixin.java
@@ -34,6 +34,20 @@ import java.util.Map;
 // the target mixin class suffers from multiple unmapped keywords that fallback to intermediary
 // i suspect that's the cause of most of these issues
 
+// Note: I Couldn't get the `genSources` task to work and linkie is acting wierd.
+// I'll attempt to provide the intermediary mappings in parentheses and use QM whenever possible.
+
+// Mixin: AbstractFurnaceBlockEntityMixin
+// Target: net.minecraft.block.entity.AbstractFurnaceBlockEntityMixin
+// Kind: Accessor-like
+// What it seems to do:
+//   - Allows for reading and modifying the "fuelTimeMap"
+//   - (De)Serializes the "BurnTime" nbt field from/to Int
+// Reason for breakage:
+// Mojang refactored this code since 1.21.2 (last instance of `net.minecraft.class_2609.method_11196`)
+// Migrating it to a global registry under net.minecraft.block.entity.FuelTimes (`net.minecraft.class_9895`)
+// See also: net.minecraft.class_2609.method_11200
+
 @Mixin(AbstractFurnaceBlockEntity.class)
 public abstract class AbstractFurnaceBlockEntityMixin {
 	@Shadow

--- a/library/item/item_content_registry/src/main/java/org/quiltmc/qsl/item/content/registry/mixin/FuelTimesBuilderMixin.java
+++ b/library/item/item_content_registry/src/main/java/org/quiltmc/qsl/item/content/registry/mixin/FuelTimesBuilderMixin.java
@@ -1,0 +1,21 @@
+package org.quiltmc.qsl.item.content.registry.mixin;
+
+import net.minecraft.block.entity.FuelTimes;
+import net.minecraft.item.Item;
+import net.minecraft.registry.tag.TagKey;
+import org.quiltmc.qsl.item.content.registry.impl.ItemContentRegistriesInitializer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(targets = {"net.minecraft.block.entity.FuelTimes$Builder"})
+public abstract class FuelTimesBuilderMixin {
+	@Inject(method = "add(Lnet/minecraft/registry/tag/TagKey;I)Lnet/minecraft/block/entity/FuelTimes$Builder;", at = @At("HEAD"), cancellable = true)
+	private void collectInitialTags(TagKey<Item> tag, int fuelTime, CallbackInfoReturnable<FuelTimes.Builder> cir) {
+		if (ItemContentRegistriesInitializer.shouldCollectInitialTags()) {
+			ItemContentRegistriesInitializer.INITIAL_FUEL_TAG_MAP.put(tag, fuelTime);
+			cir.cancel();
+		}
+	}
+}

--- a/library/item/item_content_registry/src/main/java/org/quiltmc/qsl/item/content/registry/mixin/FuelTimesMixin.java
+++ b/library/item/item_content_registry/src/main/java/org/quiltmc/qsl/item/content/registry/mixin/FuelTimesMixin.java
@@ -1,0 +1,25 @@
+package org.quiltmc.qsl.item.content.registry.mixin;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import it.unimi.dsi.fastutil.objects.Object2IntSortedMap;
+import it.unimi.dsi.fastutil.objects.Object2IntSortedMaps;
+import net.minecraft.block.entity.FuelTimes;
+import net.minecraft.item.Item;
+import org.objectweb.asm.Opcodes;
+import org.quiltmc.qsl.item.content.registry.impl.ItemContentRegistriesInitializer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(targets = {"net.minecraft.block.entity.FuelTimes"})
+public abstract class FuelTimesMixin {
+	@ModifyVariable(method = "<init>", at = @At(value = "FIELD", target = "net/minecraft/block/entity/FuelTimes.fuelTimes : Lit/unimi/dsi/fastutil/objects/Object2IntSortedMap;", opcode = Opcodes.PUTFIELD), argsOnly = true)
+	private Object2IntSortedMap<Item> returnCachedMap(Object2IntSortedMap<Item> old) {
+		if(!ItemContentRegistriesInitializer.FUEL_MAP.isEmpty()) {
+			Object2IntSortedMap<Item> conversion = Object2IntSortedMaps.emptyMap();
+			conversion.putAll(ItemContentRegistriesInitializer.FUEL_MAP);
+			return conversion;
+		}
+		return old;
+	}
+}

--- a/library/item/item_content_registry/src/main/java/org/quiltmc/qsl/item/content/registry/mixin/FuelTimesMixin.java
+++ b/library/item/item_content_registry/src/main/java/org/quiltmc/qsl/item/content/registry/mixin/FuelTimesMixin.java
@@ -6,12 +6,10 @@ import it.unimi.dsi.fastutil.objects.Object2IntSortedMap;
 import net.minecraft.block.entity.FuelTimes;
 import net.minecraft.item.Item;
 import org.quiltmc.qsl.item.content.registry.impl.ItemContentRegistriesInitializer;
-import org.spongepowered.asm.mixin.Debug;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(targets = {"net.minecraft.block.entity.FuelTimes"})
-@Debug(export = true)
 public abstract class FuelTimesMixin {
 	@WrapOperation(method = "<init>", at = @At(value = "FIELD", target = "net/minecraft/block/entity/FuelTimes.fuelTimes : Lit/unimi/dsi/fastutil/objects/Object2IntSortedMap;"))
 	private void returnCachedMap(FuelTimes instance, Object2IntSortedMap<Item> value, Operation<Void> original) {

--- a/library/item/item_content_registry/src/main/java/org/quiltmc/qsl/item/content/registry/mixin/FuelTimesMixin.java
+++ b/library/item/item_content_registry/src/main/java/org/quiltmc/qsl/item/content/registry/mixin/FuelTimesMixin.java
@@ -1,25 +1,28 @@
 package org.quiltmc.qsl.item.content.registry.mixin;
 
-import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import it.unimi.dsi.fastutil.objects.Object2IntSortedMap;
-import it.unimi.dsi.fastutil.objects.Object2IntSortedMaps;
 import net.minecraft.block.entity.FuelTimes;
 import net.minecraft.item.Item;
-import org.objectweb.asm.Opcodes;
 import org.quiltmc.qsl.item.content.registry.impl.ItemContentRegistriesInitializer;
+import org.spongepowered.asm.mixin.Debug;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Mixin(targets = {"net.minecraft.block.entity.FuelTimes"})
+@Debug(export = true)
 public abstract class FuelTimesMixin {
-	@ModifyVariable(method = "<init>", at = @At(value = "FIELD", target = "net/minecraft/block/entity/FuelTimes.fuelTimes : Lit/unimi/dsi/fastutil/objects/Object2IntSortedMap;", opcode = Opcodes.PUTFIELD), argsOnly = true)
-	private Object2IntSortedMap<Item> returnCachedMap(Object2IntSortedMap<Item> old) {
+	@WrapOperation(method = "<init>", at = @At(value = "FIELD", target = "net/minecraft/block/entity/FuelTimes.fuelTimes : Lit/unimi/dsi/fastutil/objects/Object2IntSortedMap;"))
+	private void returnCachedMap(FuelTimes instance, Object2IntSortedMap<Item> value, Operation<Void> original) {
 		if(!ItemContentRegistriesInitializer.FUEL_MAP.isEmpty()) {
-			Object2IntSortedMap<Item> conversion = Object2IntSortedMaps.emptyMap();
-			conversion.putAll(ItemContentRegistriesInitializer.FUEL_MAP);
-			return conversion;
+		 	// Is this actually right? I guess it was done this way in order for it to not have duplicate entries
+			// But wouldn't the map sort it out for us?
+			// I'm keeping this here to make it functionally equivalent with the old mixin.
+			value.clear();
+			value.putAll(ItemContentRegistriesInitializer.FUEL_MAP);
 		}
-		return old;
+
+		original.call(instance, value);
 	}
 }

--- a/library/item/item_content_registry/src/main/resources/quilt_item_content_registry.mixins.json
+++ b/library/item/item_content_registry/src/main/resources/quilt_item_content_registry.mixins.json
@@ -3,7 +3,9 @@
   "package": "org.quiltmc.qsl.item.content.registry.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "AbstractFurnaceBlockEntityMixin"
+    "AbstractFurnaceBlockEntityMixin",
+    "FuelTimesMixin",
+    "FuelTimesBuilderMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
So far I haven't really touched any code and this is here just to document what I've found while digging through code.

Mixins __fully__ explored so far:
- [x] `AbstractFurnaceBlockEntityMixin`

Mixins I've had a cursory glance:

