### PR TITLE
registry test progress

### DIFF
--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/AbstractChanneledNetworkAddon.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/AbstractChanneledNetworkAddon.java
@@ -60,7 +60,7 @@ public abstract class AbstractChanneledNetworkAddon<H> extends AbstractNetworkAd
 	public abstract void lateInit();
 
 	protected void registerPendingChannels(ChannelInfoHolder holder, NetworkPhase state) {
-		final Collection<CustomPayload.Id<?>> pending = holder.getPendingChannelsNames(state);
+		final Collection<CustomPayload.Id<?>> pending = holder.quilt$getPendingChannelsNames(state);
 
 		if (!pending.isEmpty()) {
 			this.register(new ArrayList<>(pending));

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/ChannelInfoHolder.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/ChannelInfoHolder.java
@@ -28,5 +28,5 @@ public interface ChannelInfoHolder {
 	/**
 	 * @return Channels which are declared as receivable by the other side but have not been declared yet.
 	 */
-	Collection<CustomPayload.Id<?>> getPendingChannelsNames(NetworkPhase state);
+	Collection<CustomPayload.Id<?>> quilt$getPendingChannelsNames(NetworkPhase state);
 }

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/NetworkingImpl.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/NetworkingImpl.java
@@ -78,7 +78,7 @@ public final class NetworkingImpl {
 			ids.add(new CustomPayload.Id<>(buf.readIdentifier()));
 		}
 
-		((ChannelInfoHolder) ((ServerLoginNetworkHandlerAccessor) handler).getConnection()).getPendingChannelsNames(NetworkPhase.LOGIN).addAll(ids);
+		((ChannelInfoHolder) ((ServerLoginNetworkHandlerAccessor) handler).getConnection()).quilt$getPendingChannelsNames(NetworkPhase.LOGIN).addAll(ids);
 		NetworkingImpl.LOGGER.debug("Received accepted channels from the client for \"{}\"", handler.getConnectionInfo());
 	}
 }

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/client/ClientNetworkingImpl.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/client/ClientNetworkingImpl.java
@@ -159,7 +159,7 @@ public final class ClientNetworkingImpl {
 				throw new IllegalStateException("Negotiated common packet version: %d but received packet with version: %d".formatted(addon.getNegotiatedVersion(), payload.version()));
 			}
 
-			addon.getChannelInfoHolder().getPendingChannelsNames(NetworkPhase.PLAY).addAll(payload.channels());
+			addon.getChannelInfoHolder().quilt$getPendingChannelsNames(NetworkPhase.PLAY).addAll(payload.channels());
 			NetworkingImpl.LOGGER.debug("Received accepted channels from the server");
 			sender.sendPayload(new CommonRegisterPayload(addon.getNegotiatedVersion(), CommonRegisterPayload.PLAY_PHASE, ClientPlayNetworking.getGlobalReceivers()));
 		} else {

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/common/CommonPacketsImpl.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/common/CommonPacketsImpl.java
@@ -81,7 +81,7 @@ public class CommonPacketsImpl {
 			}
 
 			// Play phase hasnt started yet, add them to the pending names.
-			addon.getChannelInfoHolder().getPendingChannelsNames(NetworkPhase.PLAY).addAll(payload.channels());
+			addon.getChannelInfoHolder().quilt$getPendingChannelsNames(NetworkPhase.PLAY).addAll(payload.channels());
 			NetworkingImpl.LOGGER.debug("Received accepted channels from the client for play phase");
 		} else {
 			addon.onCommonRegisterPacket(payload);

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/mixin/ClientConnectionMixin.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/mixin/ClientConnectionMixin.java
@@ -57,11 +57,11 @@ abstract class ClientConnectionMixin implements ChannelInfoHolder {
 	public abstract void disconnect(Text disconnectReason);
 
 	@Unique
-	private Map<NetworkPhase, Collection<CustomPayload.Id<?>>> playChannels;
+	private Map<NetworkPhase, Collection<CustomPayload.Id<?>>> pendingChannels;
 
 	@Inject(method = "<init>", at = @At("RETURN"))
 	private void initAddedFields(NetworkSide side, CallbackInfo ci) {
-		this.playChannels = new HashMap<>();
+		this.pendingChannels = new HashMap<>();
 	}
 
 	// Must be fully qualified due to mixin not working in production without it
@@ -103,6 +103,6 @@ abstract class ClientConnectionMixin implements ChannelInfoHolder {
 
 	@Override
 	public Collection<CustomPayload.Id<?>> quilt$getPendingChannelsNames(NetworkPhase state) {
-		return this.playChannels.computeIfAbsent(state, (s) -> Collections.newSetFromMap(new ConcurrentHashMap<>()));
+		return this.pendingChannels.computeIfAbsent(state, (s) -> Collections.newSetFromMap(new ConcurrentHashMap<>()));
 	}
 }

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/mixin/ClientConnectionMixin.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/mixin/ClientConnectionMixin.java
@@ -102,7 +102,7 @@ abstract class ClientConnectionMixin implements ChannelInfoHolder {
 	}
 
 	@Override
-	public Collection<CustomPayload.Id<?>> getPendingChannelsNames(NetworkPhase state) {
+	public Collection<CustomPayload.Id<?>> quilt$getPendingChannelsNames(NetworkPhase state) {
 		return this.playChannels.computeIfAbsent(state, (s) -> Collections.newSetFromMap(new ConcurrentHashMap<>()));
 	}
 }

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/mixin/PacketDispatchCodecMixin.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/mixin/PacketDispatchCodecMixin.java
@@ -34,7 +34,13 @@ import net.minecraft.network.phase.PacketDispatchCodec;
 @Mixin(PacketDispatchCodec.class)
 public abstract class PacketDispatchCodecMixin<B extends ByteBuf, V, T> implements PacketCodec<B, V> {
 	// Add the custom payload id to the error message
-	@Inject(method = "encode(Lio/netty/buffer/ByteBuf;Ljava/lang/Object;)V", at = @At(value = "NEW", target = "(Ljava/lang/String;)Lio/netty/handler/codec/EncoderException;"))
+	@Inject(
+		method = "encode(Lio/netty/buffer/ByteBuf;Ljava/lang/Object;)V",
+		at = @At(
+			value = "NEW", remap = false,
+			target = "(Ljava/lang/String;)Lio/netty/handler/codec/EncoderException;"
+		)
+	)
 	public void unknownFailure(B byteBuf, V packet, CallbackInfo ci, @Local(ordinal = 1) T packetId) {
 		CustomPayload payload = null;
 
@@ -49,7 +55,13 @@ public abstract class PacketDispatchCodecMixin<B extends ByteBuf, V, T> implemen
 		}
 	}
 
-	@Inject(method = "encode(Lio/netty/buffer/ByteBuf;Ljava/lang/Object;)V", at = @At(value = "NEW", target = "(Ljava/lang/String;Ljava/lang/Throwable;)Lio/netty/handler/codec/EncoderException;"))
+	@Inject(
+		method = "encode(Lio/netty/buffer/ByteBuf;Ljava/lang/Object;)V",
+		at = @At(
+			value = "NEW", remap = false,
+			target = "(Ljava/lang/String;Ljava/lang/Throwable;)Lio/netty/handler/codec/EncoderException;"
+		)
+	)
 	public void encodeFailure(B byteBuf, V packet, CallbackInfo ci, @Local(ordinal = 1) T packetId, @Local Exception e) {
 		CustomPayload payload = null;
 

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/mixin/client/ClientConfigurationNetworkHandlerMixin.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/mixin/client/ClientConfigurationNetworkHandlerMixin.java
@@ -50,7 +50,6 @@ abstract class ClientConfigurationNetworkHandlerMixin extends AbstractClientNetw
 		this.addon = new ClientConfigurationNetworkAddon((ClientConfigurationNetworkHandler) (Object) this, this.client);
 		// A bit of a hack but it allows the field above to be set in case someone registers handlers during INIT event which refers to said field
 		ClientNetworkingImpl.setClientConfigurationAddon(this.addon);
-		this.addon.lateInit();
 	}
 
 	@Inject(method = "onFinishConfiguration", at = @At(value = "NEW", target = "(Lnet/minecraft/client/MinecraftClient;Lnet/minecraft/network/ClientConnection;Lnet/minecraft/client/network/ClientConnectionState;)Lnet/minecraft/client/network/ClientPlayNetworkHandler;"))

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/mixin/client/ClientConfigurationNetworkHandlerMixin.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/mixin/client/ClientConfigurationNetworkHandlerMixin.java
@@ -50,6 +50,7 @@ abstract class ClientConfigurationNetworkHandlerMixin extends AbstractClientNetw
 		this.addon = new ClientConfigurationNetworkAddon((ClientConfigurationNetworkHandler) (Object) this, this.client);
 		// A bit of a hack but it allows the field above to be set in case someone registers handlers during INIT event which refers to said field
 		ClientNetworkingImpl.setClientConfigurationAddon(this.addon);
+		this.addon.lateInit();
 	}
 
 	@Inject(method = "onFinishConfiguration", at = @At(value = "NEW", target = "(Lnet/minecraft/client/MinecraftClient;Lnet/minecraft/network/ClientConnection;Lnet/minecraft/client/network/ClientConnectionState;)Lnet/minecraft/client/network/ClientPlayNetworkHandler;"))

--- a/library/core/networking/src/test/java/org/quiltmc/qsl/networking/test/CommonPacketTests.java
+++ b/library/core/networking/src/test/java/org/quiltmc/qsl/networking/test/CommonPacketTests.java
@@ -227,7 +227,7 @@ public class CommonPacketTests {
 
 		// Assert the entire packet was read
 		assertEquals(0, buf.readableBytes());
-		assertIterableEquals(List.of(SERVER_RECEIVE), channelInfoHolder.getPendingChannelsNames(NetworkPhase.PLAY));
+		assertIterableEquals(List.of(SERVER_RECEIVE), channelInfoHolder.quilt$getPendingChannelsNames(NetworkPhase.PLAY));
 
 		// Check the response we are sending back to the server
 		PacketByteBuf response = readResponse(packetSender, REGISTER_PAYLOAD_TYPE);
@@ -286,7 +286,7 @@ public class CommonPacketTests {
 
 		// Assert the entire packet was read
 		assertEquals(0, buf.readableBytes());
-		assertIterableEquals(List.of(SERVER_RECEIVE), channelInfoHolder.getPendingChannelsNames(NetworkPhase.PLAY));
+		assertIterableEquals(List.of(SERVER_RECEIVE), channelInfoHolder.quilt$getPendingChannelsNames(NetworkPhase.PLAY));
 	}
 
 	// Test handing the configuration registry packet on the server configuration handler
@@ -367,7 +367,7 @@ public class CommonPacketTests {
 		private final Map<NetworkPhase, Collection<CustomPayload.Id<?>>> playChannels = new ConcurrentHashMap<>();
 
 		@Override
-		public Collection<CustomPayload.Id<?>> getPendingChannelsNames(NetworkPhase state) {
+		public Collection<CustomPayload.Id<?>> quilt$getPendingChannelsNames(NetworkPhase state) {
 			return this.playChannels.computeIfAbsent(state, (key) -> Collections.newSetFromMap(new ConcurrentHashMap<>()));
 		}
 	}

--- a/library/core/registry/src/main/java/org/quiltmc/qsl/registry/mixin/client/ConnectScreenMixin.java
+++ b/library/core/registry/src/main/java/org/quiltmc/qsl/registry/mixin/client/ConnectScreenMixin.java
@@ -23,6 +23,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.ConnectScreen;
+import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.network.ServerAddress;
 import net.minecraft.client.network.ServerInfo;
 import net.minecraft.network.CookieStorage;
@@ -34,10 +35,10 @@ import org.quiltmc.qsl.registry.impl.sync.client.ClientRegistrySync;
 @Mixin(ConnectScreen.class)
 public class ConnectScreenMixin {
 	@Inject(
-			method = "connect(Lnet/minecraft/client/MinecraftClient;Lnet/minecraft/client/network/ServerAddress;Lnet/minecraft/client/network/ServerInfo;Lnet/minecraft/network/CookieStorage;)V",
+			method = "connect(Lnet/minecraft/client/gui/screen/Screen;Lnet/minecraft/client/MinecraftClient;Lnet/minecraft/client/network/ServerAddress;Lnet/minecraft/client/network/ServerInfo;ZLnet/minecraft/network/CookieStorage;)V",
 			at = @At(value = "HEAD")
 	)
-	private void quilt$snapshotRegistry(MinecraftClient client, ServerAddress address, ServerInfo serverInfo, CookieStorage cookieStorage, CallbackInfo ci) {
+	private static void quilt$snapshotRegistry(Screen screen, MinecraftClient client, ServerAddress address, ServerInfo info, boolean quickPlay, CookieStorage cookies, CallbackInfo ci) {
 		ClientRegistrySync.createSnapshot();
 	}
 }

--- a/library/core/registry/src/main/java/org/quiltmc/qsl/registry/mixin/client/MinecraftClientMixin.java
+++ b/library/core/registry/src/main/java/org/quiltmc/qsl/registry/mixin/client/MinecraftClientMixin.java
@@ -29,7 +29,8 @@ import org.quiltmc.qsl.registry.impl.sync.client.ClientRegistrySync;
 @ClientOnly
 @Mixin(MinecraftClient.class)
 public class MinecraftClientMixin {
-	@Inject(method = "disconnect(Lnet/minecraft/client/gui/screen/Screen;)V", at = @At("TAIL"))
+	// method_18096 is disconnect(Screen, boolean), disconnect overloads delegate to it
+	@Inject(method = "method_18096", at = @At("TAIL"))
 	private void quilt$restoreRegistries(CallbackInfo ci) {
 		ClientRegistrySync.disconnectCleanup((MinecraftClient) (Object) this);
 	}

--- a/library/core/registry/src/testmod/java/org/quiltmc/qsl/registry/test/RegistryLibEventsTest.java
+++ b/library/core/registry/src/testmod/java/org/quiltmc/qsl/registry/test/RegistryLibEventsTest.java
@@ -25,6 +25,8 @@ import net.minecraft.block.Blocks;
 import net.minecraft.block.MapColor;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
 import net.minecraft.util.Identifier;
 
 import org.quiltmc.loader.api.ModContainer;
@@ -34,7 +36,8 @@ import org.quiltmc.qsl.registry.api.event.RegistryEvents;
 public class RegistryLibEventsTest implements ModInitializer {
 	private static final Logger LOGGER = LoggerFactory.getLogger("Quilt Registry Lib Events Test");
 
-	private static final Identifier TEST_BLOCK_ID = Identifier.of("quilt_registry_test_events", "event_test_block");
+	private static final RegistryKey<Block> TEST_BLOCK_KEY =
+		RegistryKey.of(RegistryKeys.BLOCK, Identifier.of("quilt_registry_test_events", "event_test_block"));
 
 	private static boolean entryAddEventFoundBlock = false;
 
@@ -44,19 +47,22 @@ public class RegistryLibEventsTest implements ModInitializer {
 			LOGGER.info("Block {} id={} raw={} was registered in registry {}",
 					context.value(), context.id(), context.rawId(), context.registry());
 
-			if (TEST_BLOCK_ID.equals(context.id())) {
+			if (TEST_BLOCK_KEY.getValue().equals(context.id())) {
 				entryAddEventFoundBlock = true;
 			}
 		});
 
-		register(TEST_BLOCK_ID, new Block(AbstractBlock.Settings.copy(Blocks.STONE).mapColor(MapColor.BLACK)));
+		register(
+			TEST_BLOCK_KEY,
+			new Block(AbstractBlock.Settings.copy(Blocks.STONE).mapColor(MapColor.BLACK).key(TEST_BLOCK_KEY))
+		);
 
 		if (!entryAddEventFoundBlock) {
-			throw new AssertionError("Registry entry add event was not invoked on the registration of block with id " + TEST_BLOCK_ID);
+			throw new AssertionError("Registry entry add event was not invoked on the registration of block with id " + TEST_BLOCK_KEY);
 		}
 	}
 
-	static <T extends Block> T register(Identifier id, T block) {
-		return Registry.register(Registries.BLOCK, id, block);
+	static <T extends Block> T register(RegistryKey<Block> key, T block) {
+		return Registry.register(Registries.BLOCK, key.getValue(), block);
 	}
 }

--- a/library/core/registry/src/testmod/java/org/quiltmc/qsl/registry/test/RegistryLibMonitorRegistrationTest.java
+++ b/library/core/registry/src/testmod/java/org/quiltmc/qsl/registry/test/RegistryLibMonitorRegistrationTest.java
@@ -26,6 +26,8 @@ import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.MapColor;
 import net.minecraft.registry.Registries;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
 import net.minecraft.util.Identifier;
 
 import org.quiltmc.loader.api.ModContainer;
@@ -40,12 +42,18 @@ import org.quiltmc.qsl.registry.api.event.RegistryMonitor;
 public class RegistryLibMonitorRegistrationTest implements ModInitializer {
 	private static final Logger LOGGER = LoggerFactory.getLogger("Quilt Registry Lib Monitor Registration Test");
 
-	private static final Identifier TEST_BLOCK_A_ID = Identifier.of("quilt_registry_test_monitors_registration", "test_block_a");
-	private static final Identifier TEST_BLOCK_B_ID = Identifier.of("quilt_registry_test_monitors_registration", "test_block_b");
+	private static final RegistryKey<Block> TEST_BLOCK_A_KEY = RegistryKey.of(
+		RegistryKeys.BLOCK,
+		Identifier.of("quilt_registry_test_monitors_registration", "test_block_a")
+	);
+	private static final RegistryKey<Block> TEST_BLOCK_B_KEY = RegistryKey.of(
+		RegistryKeys.BLOCK,
+		Identifier.of("quilt_registry_test_monitors_registration", "test_block_b")
+	);
 
 	@Override
 	public void onInitialize(ModContainer mod) {
-		register(TEST_BLOCK_A_ID, new Block(AbstractBlock.Settings.copy(Blocks.STONE).mapColor(MapColor.BLACK)));
+		register(TEST_BLOCK_A_KEY, new Block(AbstractBlock.Settings.copy(Blocks.STONE).mapColor(MapColor.BLACK).key(TEST_BLOCK_A_KEY)));
 
 		var monitor = RegistryMonitor.create(Registries.BLOCK)
 				.filter(context -> context.id().getNamespace().equals("quilt_registry_test_monitors_registration"));
@@ -54,8 +62,8 @@ public class RegistryLibMonitorRegistrationTest implements ModInitializer {
 			LOGGER.info("[forAll event]: Block {} id={} raw={} had its registration monitored in registry {}",
 					context.value(), context.id(), context.rawId(), context.registry());
 
-			if (context.id() == TEST_BLOCK_A_ID) {
-				context.register(TEST_BLOCK_B_ID, new Block(AbstractBlock.Settings.copy(Blocks.STONE).mapColor(MapColor.BLACK)));
+			if (context.id() == TEST_BLOCK_A_KEY.getValue()) {
+				context.register(TEST_BLOCK_B_KEY.getValue(), new Block(AbstractBlock.Settings.copy(Blocks.STONE).mapColor(MapColor.BLACK).key(TEST_BLOCK_B_KEY)));
 			}
 		});
 	}

--- a/library/core/registry/src/testmod/java/org/quiltmc/qsl/registry/test/RegistryLibMonitorTest.java
+++ b/library/core/registry/src/testmod/java/org/quiltmc/qsl/registry/test/RegistryLibMonitorTest.java
@@ -28,6 +28,8 @@ import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.MapColor;
 import net.minecraft.registry.Registries;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
 import net.minecraft.util.Identifier;
 
 import org.quiltmc.loader.api.ModContainer;
@@ -37,12 +39,18 @@ import org.quiltmc.qsl.registry.api.event.RegistryMonitor;
 public class RegistryLibMonitorTest implements ModInitializer {
 	private static final Logger LOGGER = LoggerFactory.getLogger("Quilt Registry Lib Monitor Test");
 
-	private static final Identifier TEST_BLOCK_A_ID = Identifier.of("quilt_registry_test_monitors", "test_block_a");
-	private static final Identifier TEST_BLOCK_B_ID = Identifier.of("quilt_registry_test_monitors", "test_block_b");
+	private static final RegistryKey<Block> TEST_BLOCK_A_KEY = RegistryKey.of(
+		RegistryKeys.BLOCK,
+		Identifier.of("quilt_registry_test_monitors", "test_block_a")
+	);
+	private static final RegistryKey<Block> TEST_BLOCK_B_KEY = RegistryKey.of(
+		RegistryKeys.BLOCK,
+		Identifier.of("quilt_registry_test_monitors", "test_block_b")
+	);
 
 	@Override
 	public void onInitialize(ModContainer mod) {
-		Block blockA = register(TEST_BLOCK_A_ID, new Block(AbstractBlock.Settings.copy(Blocks.STONE).mapColor(MapColor.BLACK)));
+		Block blockA = register(TEST_BLOCK_A_KEY, new Block(AbstractBlock.Settings.copy(Blocks.STONE).mapColor(MapColor.BLACK).key(TEST_BLOCK_A_KEY)));
 
 		var monitor = RegistryMonitor.create(Registries.BLOCK)
 				.filter(context -> context.id().getNamespace().equals("quilt_registry_test_monitors"));
@@ -61,7 +69,7 @@ public class RegistryLibMonitorTest implements ModInitializer {
 			upcomingSet.add(context.value());
 		});
 
-		Block blockB = register(TEST_BLOCK_B_ID, new Block(AbstractBlock.Settings.copy(Blocks.STONE).mapColor(MapColor.BLACK)));
+		Block blockB = register(TEST_BLOCK_B_KEY, new Block(AbstractBlock.Settings.copy(Blocks.STONE).mapColor(MapColor.BLACK).key(TEST_BLOCK_B_KEY)));
 
 		if (!allSet.contains(blockA) || !allSet.contains(blockB)) {
 			throw new AssertionError("Entries " + allSet + " found by RegistryMonitor via forAll were not as expected");

--- a/library/core/registry/src/testmod/java/org/quiltmc/qsl/registry/test/RegistryLibSyncOrderTest.java
+++ b/library/core/registry/src/testmod/java/org/quiltmc/qsl/registry/test/RegistryLibSyncOrderTest.java
@@ -23,6 +23,8 @@ import net.fabricmc.api.EnvType;
 import net.minecraft.item.Item;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
 import net.minecraft.server.network.ServerConfigurationNetworkHandler;
 import net.minecraft.network.configuration.ConfigurationTask;
 import net.minecraft.network.packet.Packet;
@@ -49,8 +51,15 @@ import org.quiltmc.qsl.networking.api.client.ClientConfigurationNetworking;
 public class RegistryLibSyncOrderTest implements ModInitializer, DedicatedServerModInitializer, ClientModInitializer {
 	private static final CustomPayload.Id<TestPayload> PACKET_ID = new CustomPayload.Id<>(Identifier.of("quilt", "reg_sync_order_packet"));
 	private static final PacketCodec<PacketByteBuf, TestPayload> PACKET_CODEC = CustomPayload.create(TestPayload::write, TestPayload::new);
-	public static Item ITEM_A = new Item(new Item.Settings());
-	public static Item ITEM_B = new Item(new Item.Settings());
+
+	private static RegistryKey<Item> ITEM_A_KEY =
+		RegistryKey.of(RegistryKeys.ITEM, Identifier.of("quilt", "reg_sync_order_a"));
+	private static RegistryKey<Item> ITEM_B_KEY =
+		RegistryKey.of(RegistryKeys.ITEM, Identifier.of("quilt", "reg_sync_order_b"));
+
+	public static Item ITEM_A = new Item(new Item.Settings().key(ITEM_A_KEY));
+	public static Item ITEM_B = new Item(new Item.Settings().key(ITEM_B_KEY));
+
 	private static final Identifier EARLY_PHASE = Identifier.of("quilt", "reg_sync_order_early");
 
 	record TestPayload(boolean early, int a, int b) implements CustomPayload {
@@ -73,11 +82,11 @@ public class RegistryLibSyncOrderTest implements ModInitializer, DedicatedServer
 	@Override
 	public void onInitialize(ModContainer mod) {
 		if (MinecraftQuiltLoader.getEnvironmentType() == EnvType.CLIENT) {
-			Registry.register(Registries.ITEM, Identifier.of("quilt", "reg_sync_order_a"), ITEM_A);
-			Registry.register(Registries.ITEM, Identifier.of("quilt", "reg_sync_order_b"), ITEM_B);
+			Registry.register(Registries.ITEM, ITEM_A_KEY.getValue(), ITEM_A);
+			Registry.register(Registries.ITEM, ITEM_B_KEY.getValue(), ITEM_B);
 		} else {
-			Registry.register(Registries.ITEM, Identifier.of("quilt", "reg_sync_order_b"), ITEM_B);
-			Registry.register(Registries.ITEM, Identifier.of("quilt", "reg_sync_order_a"), ITEM_A);
+			Registry.register(Registries.ITEM, ITEM_B_KEY.getValue(), ITEM_B);
+			Registry.register(Registries.ITEM, ITEM_A_KEY.getValue(), ITEM_A);
 		}
 
 		PayloadTypeRegistry.configurationS2C().register(PACKET_ID, PACKET_CODEC);

--- a/library/core/registry/src/testmod/java/org/quiltmc/qsl/registry/test/RegistryLibSyncTest.java
+++ b/library/core/registry/src/testmod/java/org/quiltmc/qsl/registry/test/RegistryLibSyncTest.java
@@ -32,6 +32,7 @@ import net.minecraft.item.Item;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.SimpleRegistry;
 import net.minecraft.util.Identifier;
 
@@ -118,11 +119,16 @@ public class RegistryLibSyncTest implements ModInitializer {
 
 	@SuppressWarnings("unchecked")
 	static Identifier register(int i) {
-		var id = Identifier.of(NAMESPACE, "entry_" + i);
-		var block = new Block(AbstractBlock.Settings.copy(Blocks.STONE).mapColor(MapColor.BLACK));
+		final Identifier id = Identifier.of(NAMESPACE, "entry_" + i);
+        final Block block = new Block(
+			AbstractBlock.Settings.copy(Blocks.STONE)
+				.mapColor(MapColor.BLACK)
+				.key(RegistryKey.of(RegistryKeys.BLOCK, id))
+		);
+		final BlockItem item = new BlockItem(block, new Item.Settings().key(RegistryKey.of(RegistryKeys.ITEM, id)));
 
 		Registry.register(Registries.BLOCK, id, block);
-		Registry.register(Registries.ITEM, id, new BlockItem(block, new Item.Settings()));
+		Registry.register(Registries.ITEM, id, item);
 		RegistrySynchronization.setEntryOptional((SimpleRegistry<Item>) Registries.ITEM, id);
 		return id;
 	}

--- a/library/core/registry/src/testmod/java/org/quiltmc/qsl/registry/test/dynamic/RegistryLibDynamicRegistryTest.java
+++ b/library/core/registry/src/testmod/java/org/quiltmc/qsl/registry/test/dynamic/RegistryLibDynamicRegistryTest.java
@@ -25,8 +25,9 @@ import net.minecraft.registry.DynamicRegistrySync;
 import net.minecraft.registry.Holder;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.tag.TagKey;
-import net.minecraft.test.GameTest;
 import net.minecraft.test.GameTestException;
+import net.minecraft.test.TestContext;
+import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 import org.quiltmc.loader.api.ModContainer;
@@ -37,6 +38,7 @@ import org.quiltmc.qsl.registry.api.event.RegistryEvents;
 import org.quiltmc.qsl.tag.api.TagRegistry;
 import org.quiltmc.qsl.testing.api.game.QuiltGameTest;
 import org.quiltmc.qsl.testing.api.game.QuiltTestContext;
+import org.quiltmc.qsl.testing.api.game.annotation.GameTest;
 
 public class RegistryLibDynamicRegistryTest implements QuiltGameTest, ModInitializer {
 	public static final String NAMESPACE = "quilt_registry_testmod";
@@ -62,16 +64,17 @@ public class RegistryLibDynamicRegistryTest implements QuiltGameTest, ModInitial
 		var greetingsRegistry = ctx.getWorld().getRegistryManager().getLookupOrThrow(Greetings.REGISTRY_KEY);
 
 		ctx.succeedIf(() -> {
-			ctx.assertTrue(DynamicRegistryFlag.isOptional(Greetings.REGISTRY_KEY.getValue()), "Registry should always have the OPTIONAL flag enabled");
-			ctx.assertTrue(greetingsRegistry.containsId(GREETING_A_ID), "Registry should contain modded data value from datapack");
-			ctx.assertTrue(Objects.requireNonNull(greetingsRegistry.get(GREETING_A_ID)).equals(GREETING_A), "Modded value should be properly parsed from data file");
-			ctx.assertTrue(GREETING_B.equals(greetingsRegistry.get(GREETING_B_ID)), "Registry should contain modded data value from event");
+			assertTrue(ctx, DynamicRegistryFlag.isOptional(Greetings.REGISTRY_KEY.getValue()), "Registry should always have the OPTIONAL flag enabled");
+			assertTrue(ctx, greetingsRegistry.containsId(GREETING_A_ID), "Registry should contain modded data value from datapack");
+			assertTrue(ctx, Objects.requireNonNull(greetingsRegistry.get(GREETING_A_ID)).equals(GREETING_A), "Modded value should be properly parsed from data file");
+			assertTrue(ctx, GREETING_B.equals(greetingsRegistry.get(GREETING_B_ID)), "Registry should contain modded data value from event");
 		});
 	}
 
 	@GameTest(structureName = EMPTY_STRUCTURE)
 	public void greetingsGetSynced(QuiltTestContext ctx) {
-		ctx.succeedIf(() -> ctx.assertTrue(
+		ctx.succeedIf(() -> assertTrue(
+			ctx,
 			DynamicRegistrySync.streamReloadableSyncedRegistries(ctx.getWorld().getServer().getLayeredRegistryManager()).anyMatch(e -> e.key().equals(Greetings.REGISTRY_KEY)),
 			"Modded registry key should appear in the list of synced dynamic registries"
 		));
@@ -80,13 +83,13 @@ public class RegistryLibDynamicRegistryTest implements QuiltGameTest, ModInitial
 	@GameTest(structureName = EMPTY_STRUCTURE)
 	public void greetingsTagGetLoaded(QuiltTestContext ctx) {
 		var tagValuesSet = TagRegistry.stream(Greetings.REGISTRY_KEY).collect(Collectors.toSet());
-		ctx.failIf(() -> ctx.assertTrue(tagValuesSet.isEmpty(), "tagValuesSet should always be populated with at least 1 object"));
+		ctx.failIfEver(() -> assertTrue(ctx, tagValuesSet.isEmpty(), "tagValuesSet should always be populated with at least 1 object"));
 
-		ctx.succeedIf(() -> ctx.assertTrue(tagValuesSet.stream().anyMatch(tagValues -> {
+		ctx.succeedIf(() -> assertTrue(ctx, tagValuesSet.stream().anyMatch(tagValues -> {
 			var greetingsRegistry = ctx.getWorld().getRegistryManager().getLookupOrThrow(Greetings.REGISTRY_KEY);
 			var greetingsA = greetingsRegistry.get(GREETING_A_ID);
 
-			ctx.assertTrue(Objects.nonNull(greetingsRegistry.get(GREETING_A_ID)), "Registry should contain modded data value from datapack");
+			assertTrue(ctx, Objects.nonNull(greetingsRegistry.get(GREETING_A_ID)), "Registry should contain modded data value from datapack");
 
 			var heldIds = tagValues.values().stream().map(Holder::getValue).collect(Collectors.toSet());
 			return tagValues.key().equals(GREETING_TEST_TAG) && heldIds.contains(greetingsA);
@@ -94,13 +97,20 @@ public class RegistryLibDynamicRegistryTest implements QuiltGameTest, ModInitial
 	}
 
 	@GameTest(structureName = EMPTY_STRUCTURE)
-	public void dynamicMetaregistryFreezes(QuiltTestContext ctx) {
+	public void dynamicMetaRegistryFreezes(QuiltTestContext ctx) {
 		ctx.succeedIf(() -> {
 			try {
 				DynamicMetaRegistry.register(RegistryKey.ofRegistry(id("a")), Codec.INT);
-				throw new GameTestException("DynamicMetaRegistry should not allow registration after init");
+				throw new GameTestException(
+					Text.literal("DynamicMetaRegistry should not allow registration after init"),
+					(int) ctx.getTick()
+				);
 			} catch (IllegalStateException ignored) {
 			}
 		});
+	}
+
+	private static void assertTrue(TestContext context, boolean value, String error) {
+		context.assertTrue(value, Text.literal(error));
 	}
 }

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/client/IntegratedServerLoaderMixin.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/client/IntegratedServerLoaderMixin.java
@@ -49,6 +49,10 @@ import org.quiltmc.qsl.base.api.util.TriState;
 import org.quiltmc.qsl.resource.loader.api.ResourceLoaderEvents;
 import org.quiltmc.qsl.resource.loader.impl.ResourceLoaderEventContextsImpl;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+
 @ClientOnly
 @Mixin(IntegratedServerLoader.class)
 public abstract class IntegratedServerLoaderMixin {
@@ -90,22 +94,23 @@ public abstract class IntegratedServerLoaderMixin {
 		return exception; // noop
 	}
 
-	@Inject(
-			method = "method_57775(Lnet/minecraft/world/storage/WorldSaveStorage$Session;Lnet/minecraft/server/WorldStem;Lnet/minecraft/resource/pack/PackManager;Ljava/lang/Runnable;)V",
-			at = @At(
-					value = "INVOKE",
-					target = "Lnet/minecraft/server/integrated/IntegratedServerLoader;askForBackup(Lnet/minecraft/world/storage/WorldSaveStorage$Session;ZLjava/lang/Runnable;Ljava/lang/Runnable;)V"
-			),
-			locals = LocalCapture.CAPTURE_FAILHARD,
-			cancellable = true
+	@WrapOperation(
+		method = "method_57775(Lnet/minecraft/world/storage/WorldSaveStorage$Session;Lnet/minecraft/server/WorldStem;" +
+			"Lnet/minecraft/resource/pack/PackManager;Ljava/lang/Runnable;)V",
+		at = @At(
+			value = "INVOKE",
+			target = "Lnet/minecraft/server/integrated/IntegratedServerLoader;askForBackup(Lnet/minecraft/world/storage/WorldSaveStorage$Session;ZLjava/lang/Runnable;Ljava/lang/Runnable;)V"
+		)
 	)
-	private void onBackupExperimentalWarning(WorldSaveStorage.Session session, WorldStem worldStem, PackManager packManager, Runnable runnable, CallbackInfo ci, SaveProperties saveProperties, boolean legacyCustomized, boolean unstable) {
+	private void onBackupExperimentalWarning(
+		IntegratedServerLoader instance, WorldSaveStorage.Session session, boolean legacyCustomized,
+		Runnable onProceeded, Runnable onCancelled,
+		Operation<Void> original
+	) {
 		if (EXPERIMENTAL_SCREEN_OVERRIDE.toBooleanOrElse(true) && !legacyCustomized) {
-			// Copied from the second lambda in askForBackup
-			worldStem.close();
-			session.method_54532();
-			runnable.run();
-			ci.cancel();
+			onCancelled.run();
+		} else {
+			original.call(instance, session, legacyCustomized, onProceeded, onCancelled);
 		}
 	}
 

--- a/library/core/testing/src/main/java/org/quiltmc/qsl/testing/impl/game/QuiltGameTestImpl.java
+++ b/library/core/testing/src/main/java/org/quiltmc/qsl/testing/impl/game/QuiltGameTestImpl.java
@@ -95,17 +95,16 @@ public final class QuiltGameTestImpl implements ModInitializer {
 	 * @param method the method that executes the test
 	 * @return the test function
 	 */
-	public static @NotNull QuiltTestInstance getTestFunction(@NotNull Method method, Identifier id) {
+	public static @NotNull QuiltTestInstance getTestFunction(@NotNull Method method, GameTest annotation, Identifier id) {
 		var data = QuiltGameTestImpl.getDataForTestClass(method.getDeclaringClass());
 
-		var gameTest = method.getAnnotation(GameTest.class);
 		String testSuiteName = method.getDeclaringClass().getSimpleName().toLowerCase(Locale.ROOT);
 		var testCaseName = data.namespace() + ':' + testSuiteName + '/' + method.getName().toLowerCase(Locale.ROOT);
 
 		var structureName = testCaseName;
 
-		if (!gameTest.structureName().isEmpty()) {
-			structureName = gameTest.structureName();
+		if (!annotation.structureName().isEmpty()) {
+			structureName = annotation.structureName();
 
 			var structurePrefix = method.getDeclaringClass().getAnnotation(TestStructureNamePrefix.class);
 			if (structurePrefix != null) {
@@ -117,14 +116,14 @@ public final class QuiltGameTestImpl implements ModInitializer {
 				new TestData<>(
 					Holder.createDirect(new TestEnvironmentDefinition.AllOf(List.of())),
 					Identifier.parse(structureName),
-					gameTest.timeout(),
-					(int) gameTest.startDelay(),
-					gameTest.required(),
-					gameTest.rotation(),
-					gameTest.manualOnly(),
-					gameTest.maxAttempts(),
-					gameTest.requiredSuccesses(),
-					gameTest.skyAccess()
+					annotation.timeout(),
+					(int) annotation.startDelay(),
+					annotation.required(),
+					annotation.rotation(),
+					annotation.manualOnly(),
+					annotation.maxAttempts(),
+					annotation.requiredSuccesses(),
+					annotation.skyAccess()
 				),
 				QuiltGameTestImpl.getTestMethodInvoker(data, method),
 				id,
@@ -201,10 +200,15 @@ public final class QuiltGameTestImpl implements ModInitializer {
 
 		GAME_TESTS.put(testClass, new GameTestData(modId, instance));
 		Stream.of(testClass.getDeclaredMethods()).sorted(Comparator.comparing(Method::getName)).forEach(method -> {
-			var methodName = method.getName().toLowerCase(Locale.ROOT);
-			var test = QuiltGameTestImpl.getTestFunction(method, Identifier.of(modId, methodName));
+			final GameTest annotation = method.getAnnotation(GameTest.class);
+			// only consider annotated methods
+			if (annotation != null) {
+                final String methodName = method.getName().toLowerCase(Locale.ROOT);
+                final QuiltTestInstance test =
+					QuiltGameTestImpl.getTestFunction(method, annotation, Identifier.of(modId, methodName));
 
-			QUILT_TESTS.put(test.id(), test);
+				QUILT_TESTS.put(test.id(), test);
+			}
 		});
 
 		LOGGER.debug("Registered test class {} for mod {}", testClass.getCanonicalName(), modId);

--- a/library/core/testing/src/main/resources/quilt_testing.accesswidener
+++ b/library/core/testing/src/main/resources/quilt_testing.accesswidener
@@ -3,5 +3,3 @@ accessWidener   v2  named
 accessible  class   net/minecraft/structure/StructureTemplateManager$Source
 
 accessible  method  net/minecraft/structure/StructureTemplateManager$Source <init>  (Ljava/util/function/Function;Ljava/util/function/Supplier;)V
-
-extendable  class   net/minecraft/test/TestFunction

--- a/library/entity/entity_extensions/src/main/resources/quilt_entity_extensions.accesswidener
+++ b/library/entity/entity_extensions/src/main/resources/quilt_entity_extensions.accesswidener
@@ -20,4 +20,4 @@ transitive-accessible  class   net/minecraft/village/TradeOffers$TypeAwareBuyFor
 # Internal Villager AWs
 accessible class net/minecraft/village/TradeOffers$TypeAwareBuyForOneEmeraldFactory
 mutable field net/minecraft/village/TradeOffers PROFESSION_TO_LEVELED_TRADE Ljava/util/Map;
-mutable field net/minecraft/village/TradeOffers WANDERING_TRADER_TRADES     Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
+mutable field net/minecraft/village/TradeOffers WANDERING_TRADER_TRADES     Ljava/util/List;

--- a/library/entity/entity_extensions/src/main/resources/quilt_entity_extensions.accesswidener
+++ b/library/entity/entity_extensions/src/main/resources/quilt_entity_extensions.accesswidener
@@ -6,7 +6,6 @@ transitive-accessible   method  net/minecraft/entity/SpawnRestriction           
 
 # Villager TAWs
 transitive-accessible  field   net/minecraft/village/VillagerType  BIOME_TO_TYPE  Ljava/util/Map;
-transitive-accessible  method  net/minecraft/village/VillagerType  <init>         (Ljava/lang/String;)V
 transitive-accessible  class   net/minecraft/village/TradeOffers$BuyForOneEmeraldFactory
 transitive-accessible  class   net/minecraft/village/TradeOffers$EnchantBookFactory
 transitive-accessible  class   net/minecraft/village/TradeOffers$ProcessItemFactory


### PR DESCRIPTION
this fixes `:core:testing:runTestmodClient`

it also gets `:core:registry:runTestmodClient` to *launch*, but trying to load a world kicks you back to the world select screen with no error, it just logs
> [16:40:10] [Render thread/INFO] (Minecraft) Loaded 1373 recipes
[16:40:10] [Render thread/INFO] (Minecraft) Loaded 1484 advancements

creating a new world does work for some reason