### PR TITLE
trade offers

### DIFF
--- a/library/entity/entity_extensions/src/main/java/org/quiltmc/qsl/entity/extensions/api/TradeOfferHelper.java
+++ b/library/entity/entity_extensions/src/main/java/org/quiltmc/qsl/entity/extensions/api/TradeOfferHelper.java
@@ -18,202 +18,214 @@
 package org.quiltmc.qsl.entity.extensions.api;
 
 import java.util.Collection;
-import java.util.List;
-import java.util.function.Consumer;
+import java.util.Objects;
 
+import net.minecraft.registry.RegistryKey;
 import net.minecraft.util.Identifier;
 import net.minecraft.village.TradeOffers;
 import net.minecraft.village.VillagerProfession;
+
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 import org.quiltmc.qsl.entity.extensions.impl.TradeOfferInternals;
 
 /**
  * Utilities to help with registration of trade offers.
  */
 public final class TradeOfferHelper {
-	/**
-	 * Registers trade offer factories for use by villagers.
-	 * This adds the same trade offers to current and rebalanced trades.
-	 * To add separate offers for the rebalanced trade experiment, use
-	 * {@link #registerVillagerOffers(VillagerProfession, int, VillagerOffersAdder)}.
-	 *
-	 * <p>Below is an example of registering a trade offer factory to be added a blacksmith with a profession level of 3:
-	 * <blockquote><pre>
-	 * TradeOfferHelper.registerVillagerOffers(VillagerProfession.BLACKSMITH, 3, factories -> {
-	 * 	factories.add(new CustomTradeFactory(...);
-	 * });
-	 * </pre></blockquote>
-	 *
-	 * @param profession the villager profession to assign the trades to
-	 * @param level the profession level the villager must be to offer the trades
-	 * @param factories a consumer to provide the factories
-	 */
-	public static void registerVillagerOffers(VillagerProfession profession, int level, Consumer<List<TradeOffers.Factory>> factories) {
-		TradeOfferInternals.registerVillagerOffers(profession, level, (trades, rebalanced) -> factories.accept(trades));
-	}
-
-	/**
-	 * Registers trade offer factories for use by villagers.
-	 * This method allows separate offers to be added depending on whether the rebalanced
-	 * trade experiment is enabled.
-	 * If a particular profession's rebalanced trade offers are not added at all, it falls back
-	 * to the regular trade offers.
-	 *
-	 * <p>Below is an example, of registering a trade offer factory to be added a blacksmith with a profession level of 3:
-	 * <blockquote><pre>
-	 * TradeOfferHelper.registerVillagerOffers(VillagerProfession.BLACKSMITH, 3, (factories, rebalanced) -> {
-	 * 	factories.add(new CustomTradeFactory(...);
-	 * });
-	 * </pre></blockquote>
-	 *
-	 * <p><strong>Experimental feature</strong>. This API may receive changes as necessary to adapt to further experiment changes.
-	 *
-	 * @param profession the villager profession to assign the trades to
-	 * @param level the profession level the villager must be to offer the trades
-	 * @param factories a consumer to provide the factories
-	 */
-	@ApiStatus.Experimental
-	public static void registerVillagerOffers(VillagerProfession profession, int level, VillagerOffersAdder factories) {
-		TradeOfferInternals.registerVillagerOffers(profession, level, factories);
-	}
-
-	/**
-	 * Registers trade offer factories for use by wandering trades.
-	 * This does not add offers for the rebalanced trade experiment.
-	 * To add rebalanced trades, use {@link #registerRebalancedWanderingTraderOffers}.
-	 *
-	 * @param level the level the trades
-	 * @param factory a consumer to provide the factories
-	 */
-	public static void registerWanderingTraderOffers(int level, Consumer<List<TradeOffers.Factory>> factory) {
-		TradeOfferInternals.registerWanderingTraderOffers(level, factory);
-	}
-
-	/**
-	 * Registers trade offer factories for use by wandering trades.
-	 * This only adds offers for the rebalanced trade experiment.
-	 * To add regular trades, use {@link #registerWanderingTraderOffers(int, Consumer)}.
-	 *
-	 * <p><strong>Experimental feature</strong>. This API may receive changes as necessary to adapt to further experiment changes.
-	 *
-	 * @param factory a consumer to add trade offers
-	 */
-	@ApiStatus.Experimental
-	public static synchronized void registerRebalancedWanderingTraderOffers(Consumer<WanderingTraderOffersBuilder> factory) {
-		factory.accept(new TradeOfferInternals.WanderingTraderOffersBuilderImpl());
-	}
-
 	private TradeOfferHelper() {
-	}
-
-	@FunctionalInterface
-	public interface VillagerOffersAdder {
-		void onRegister(List<TradeOffers.Factory> factories, boolean rebalanced);
+		throw new UnsupportedOperationException(
+			TradeOfferHelper.class.getSimpleName() + " contains only static members"
+		);
 	}
 
 	/**
-	 * A builder for rebalanced wandering trader offers.
+	 * Registers offer factories for use by villagers.
+	 * <p>
+	 * This adds offers to the default (non-rebalanced) trades, but they may be used with the rebalanced trade
+	 * experiment as well if no rebalanced trades override them.<br>
+	 * To add separate offers for the rebalanced trade experiment, use
+	 * {@link #addToExperimentalVillagerOfferPool(RegistryKey, int, TradeOffers.Factory...)}.
+	 * <p>
+	 * Below is an example of registering an offer factory to be added a blacksmith with a profession level of 3:
+	 * <blockquote><pre>
+	 * TradeOfferHelper.registerVillagerOffers(
+	 * 	VillagerProfession.BLACKSMITH, 3,
+	 * 	new CustomTradeFactory(...),
+	 * 	new CustomTradeFactory(...)
+	 * );
+	 * </pre></blockquote>
 	 *
-	 * <p><strong>Experimental feature</strong>. This API may receive changes as necessary to adapt to further experiment changes.
+	 * @param profession	the registry key of the villager profession to assign the trades to
+	 * @param level			the profession level the villager must be to offer the trades; must not be negative
+	 * @param factories		the offer factories to add; must not be empty
 	 *
-	 * @see #registerRebalancedWanderingTraderOffers(Consumer)
+	 * @see #addToVillagerOfferPool(RegistryKey, int, Collection)
 	 */
-	@ApiStatus.NonExtendable
+	public static synchronized void addToVillagerOfferPool(
+		@NotNull
+		RegistryKey<VillagerProfession> profession,
+		int level,
+		@NotNull
+		TradeOffers.Factory... factories
+	) {
+		TradeOfferInternals.addToVillagerOfferPool(profession, level, factories);
+	}
+
+	/**
+	 * @see #addToVillagerOfferPool(RegistryKey, int, TradeOffers.Factory...)
+	 */
+	public static synchronized void addToVillagerOfferPool(
+		@NotNull
+		RegistryKey<VillagerProfession> profession,
+		int level,
+		@NotNull
+		Collection<TradeOffers.Factory> factories
+	) {
+		Objects.requireNonNull(factories, "factories must not be null");
+		addToVillagerOfferPool(profession, level, factories.toArray(new TradeOffers.Factory[0]));
+	}
+
+	/**
+	 * Registers offer factories for use by villagers when the rebalanced trade experiment is enabled.
+	 * <p>
+	 * Below is an example of registering an offer factory to be added a blacksmith with a profession level of 3:
+	 * <blockquote><pre>
+	 * TradeOfferHelper.registerRebalancedVillagerOffers(
+	 * 	VillagerProfession.BLACKSMITH, 3,
+	 * 	new CustomTradeFactory(...),
+	 * 	new CustomTradeFactory(...)
+	 * );
+	 * </pre></blockquote>
+	 * <p>
+	 * <strong>Experimental feature</strong>. This API may receive changes as necessary to adapt to further experiment
+	 * changes.
+	 *
+	 * @param profession 	the registry key of the villager profession to assign the trades to
+	 * @param level			the profession level the villager must be to offer the trades; must not be negative
+	 * @param factories 	the offer factories to add; must not be empty
+	 */
 	@ApiStatus.Experimental
-	public interface WanderingTraderOffersBuilder {
+	public static synchronized void addToExperimentalVillagerOfferPool(
+		@NotNull
+		RegistryKey<VillagerProfession> profession,
+		int level,
+		@NotNull
+		TradeOffers.Factory... factories
+	) {
+		TradeOfferInternals.addToExperimentalVillagerOfferPool(profession, level, factories);
+	}
+
+	/**
+	 * @see #addToExperimentalVillagerOfferPool(RegistryKey, int, TradeOffers.Factory...)
+	 */
+	@ApiStatus.Experimental
+	public static synchronized void addToExperimentalVillagerOfferPool(
+		@NotNull
+		RegistryKey<VillagerProfession> profession,
+		int level,
+		@NotNull
+		Collection<TradeOffers.Factory> factories
+	) {
+		addToExperimentalVillagerOfferPool(profession, level, factories.toArray(new TradeOffers.Factory[0]));
+	}
+
+	/**
+	 * Adds offer factories to the identified Wandering Trader offer {@code pool}.
+	 * <p>
+	 * Identifiers for vanilla's pools can be found in {@link VanillaWanderingTraderPoolIds}.<br>
+	 * If the passed identifier hasn't been
+	 * {@linkplain #registerWanderingTraderPool(Identifier, int, TradeOffers.Factory...) registered} yet,
+	 * then the passed {@code factories} will only be added to the pool once it has been registered.
+	 *
+	 * @param id		the identifier of the offer pool
+	 * @param factories the offer factories to; must not be empty
+	 *
+	 * @see #addToWanderingTraderOfferPool(Identifier, Collection)
+	 */
+	public static synchronized void addToWanderingTraderOfferPool(
+		@NotNull
+		Identifier id,
+		@NotNull
+		TradeOffers.Factory... factories
+	) {
+		TradeOfferInternals.addToWanderingTraderOfferPool(id, factories);
+	}
+
+	/**
+	 * @see #addToWanderingTraderOfferPool(Identifier, TradeOffers.Factory...)
+	 */
+	public static synchronized void addToWanderingTraderOfferPool(
+		Identifier pool, Collection<TradeOffers.Factory> factories
+	) {
+		TradeOfferInternals.addToWanderingTraderOfferPool(pool, factories.toArray(new TradeOffers.Factory[0]));
+	}
+
+	/**
+	 * Registers a new Wandering Trader offer pool.
+	 *
+	 * @param id		the identifier of the offer pool
+	 * @param count		the number of offers to select from the pool; must be greater than {@code 0}
+	 * @param factories the offer factories that make up the pool; must not be empty
+	 *
+	 * @throws IllegalArgumentException if a pool with the passed {@code id} has already been registered
+	 *
+	 * @see #registerWanderingTraderPool(Identifier, int, Collection)
+	 */
+	public static synchronized void registerWanderingTraderPool(
+		@NotNull
+		Identifier id,
+		int count,
+		@NotNull
+		TradeOffers.Factory... factories
+	) {
+		TradeOfferInternals.registerWanderingTraderPool(id, count, factories);
+	}
+
+	/**
+	 * @see #registerWanderingTraderPool(Identifier, int, TradeOffers.Factory...)
+	 */
+	public static synchronized void registerWanderingTraderPool(
+		@NotNull
+		Identifier pool,
+		int count,
+		@NotNull
+		Collection<TradeOffers.Factory> factories
+	) {
+		TradeOfferInternals.registerWanderingTraderPool(pool, count, factories.toArray(new TradeOffers.Factory[0]));
+	}
+
+	/**
+	 * Identifiers for vanilla's Wandering Trader offer pools.
+	 */
+	public static final class VanillaWanderingTraderPoolIds {
+		private VanillaWanderingTraderPoolIds() {
+			throw new UnsupportedOperationException(
+				VanillaWanderingTraderPoolIds.class.getSimpleName() + " contains only static members"
+			);
+		}
+
 		/**
 		 * The pool ID for the "buy items" pool.
-		 * Two trade offers are picked from this pool.
+		 * Two offers are picked from this pool.
 		 *
 		 * <p>In vanilla, this pool contains offers to buy water buckets, baked potatoes, etc.
 		 * for emeralds.
 		 */
-		Identifier BUY_ITEMS_POOL = Identifier.of("minecraft", "buy_items");
+		public static final Identifier BUY_ITEMS = Identifier.ofDefault("buy_items");
 		/**
 		 * The pool ID for the "sell special items" pool.
-		 * Two trade offers are picked from this pool.
+		 * Two offers are picked from this pool.
 		 *
 		 * <p>In vanilla, this pool contains offers to sell logs, enchanted iron pickaxes, etc.
 		 */
-		Identifier SELL_SPECIAL_ITEMS_POOL = Identifier.of("minecraft", "sell_special_items");
+		public static final Identifier SELL_SPECIAL_ITEMS = Identifier.ofDefault("sell_special_items");
 		/**
 		 * The pool ID for the "sell common items" pool.
-		 * Five trade offers are picked from this pool.
+		 * Five offers are picked from this pool.
 		 *
 		 * <p>In vanilla, this pool contains offers to sell flowers, saplings, etc.
 		 */
-		Identifier SELL_COMMON_ITEMS_POOL = Identifier.of("minecraft", "sell_common_items");
-
-		/**
-		 * Adds a new pool to the offer list. Exactly {@code count} offers are picked from
-		 * {@code factories} and offered to customers.
-		 * @param id the ID to be assigned to this pool, to allow further modification
-		 * @param count the number of offers to be picked from {@code factories}
-		 * @param factories the trade offer factories
-		 * @return this builder, for chaining
-		 * @throws IllegalArgumentException if {@code count} is not positive or if {@code factories} is empty
-		 */
-		WanderingTraderOffersBuilder pool(Identifier id, int count, TradeOffers.Factory... factories);
-
-		/**
-		 * Adds a new pool to the offer list. Exactly {@code count} offers are picked from
-		 * {@code factories} and offered to customers.
-		 * @param id the ID to be assigned to this pool, to allow further modification
-		 * @param count the number of offers to be picked from {@code factories}
-		 * @param factories the trade offer factories
-		 * @return this builder, for chaining
-		 * @throws IllegalArgumentException if {@code count} is not positive or if {@code factories} is empty
-		 */
-		default WanderingTraderOffersBuilder pool(Identifier id, int count, Collection<? extends TradeOffers.Factory> factories) {
-			return pool(id, count, factories.toArray(TradeOffers.Factory[]::new));
-		}
-
-		/**
-		 * Adds trade offers to the offer list. All offers from {@code factories} are
-		 * offered to each customer.
-		 * @param id the ID to be assigned to this pool, to allow further modification
-		 * @param factories the trade offer factories
-		 * @return this builder, for chaining
-		 * @throws IllegalArgumentException if {@code factories} is empty
-		 */
-		default WanderingTraderOffersBuilder addAll(Identifier id, Collection<? extends TradeOffers.Factory> factories) {
-			return pool(id, factories.size(), factories);
-		}
-
-		/**
-		 * Adds trade offers to the offer list. All offers from {@code factories} are
-		 * offered to each customer.
-		 * @param id the ID to be assigned to this pool, to allow further modification
-		 * @param factories the trade offer factories
-		 * @return this builder, for chaining
-		 * @throws IllegalArgumentException if {@code factories} is empty
-		 */
-		default WanderingTraderOffersBuilder addAll(Identifier id, TradeOffers.Factory... factories) {
-			return pool(id, factories.length, factories);
-		}
-
-		/**
-		 * Adds trade offers to an existing pool identified by an ID.
-		 *
-		 * <p>See the constants for vanilla trade offer pool IDs that are always available.
-		 * @param pool the pool ID
-		 * @param factories the trade offer factories
-		 * @return this builder, for chaining
-		 * @throws IndexOutOfBoundsException if {@code pool} is out of bounds
-		 */
-		WanderingTraderOffersBuilder addOffersToPool(Identifier pool, TradeOffers.Factory... factories);
-
-		/**
-		 * Adds trade offers to an existing pool identified by an ID.
-		 *
-		 * <p>See the constants for vanilla trade offer pool IDs that are always available.
-		 * @param pool the pool ID
-		 * @param factories the trade offer factories
-		 * @return this builder, for chaining
-		 * @throws IndexOutOfBoundsException if {@code pool} is out of bounds
-		 */
-		default WanderingTraderOffersBuilder addOffersToPool(Identifier pool, Collection<TradeOffers.Factory> factories) {
-			return addOffersToPool(pool, factories.toArray(TradeOffers.Factory[]::new));
-		}
+		public static final Identifier SELL_COMMON_ITEMS = Identifier.ofDefault("sell_common_items");
 	}
 }

--- a/library/entity/entity_extensions/src/main/java/org/quiltmc/qsl/entity/extensions/impl/TradeOfferInternals.java
+++ b/library/entity/entity_extensions/src/main/java/org/quiltmc/qsl/entity/extensions/impl/TradeOfferInternals.java
@@ -17,122 +17,157 @@
 
 package org.quiltmc.qsl.entity.extensions.impl;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Consumer;
+import java.util.stream.Stream;
 
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
-import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+
+import net.minecraft.registry.RegistryKey;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.Util;
+
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.quiltmc.qsl.entity.extensions.mixin.accessor.TradeOffersAccessor;
 
 import net.minecraft.village.TradeOffers;
 import net.minecraft.village.VillagerProfession;
-import org.quiltmc.qsl.entity.extensions.api.TradeOfferHelper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class TradeOfferInternals {
-	private static final Logger LOGGER = LoggerFactory.getLogger("quilt-entity-extensions");
-
 	private TradeOfferInternals() {
+		throw new UnsupportedOperationException(
+			TradeOfferInternals.class.getSimpleName() + " contains only static members"
+		);
 	}
 
-	/*
-	removed: making the rebalanced map mutable as the rebalanced trades are no longer separated.
-	 */
+	private static final Multimap<Identifier, TradeOffers.Factory[]> PENDING_WANDERING_TRADER_FACTORIES_BY_ID =
+		HashMultimap.create();
 
 	// synchronized guards against concurrent modifications - Vanilla does not mutate the underlying arrays (as of 1.16),
 	// so reads will be fine without locking.
-	public static synchronized void registerVillagerOffers(VillagerProfession profession, int level, TradeOfferHelper.VillagerOffersAdder factory) {
-		Objects.requireNonNull(profession, "VillagerProfession may not be null.");
-		registerOffers(TradeOffers.PROFESSION_TO_LEVELED_TRADE.computeIfAbsent(profession, key -> new Int2ObjectOpenHashMap<>()), level, trades -> factory.onRegister(trades, false));
+	public static synchronized void addToVillagerOfferPool(
+		@NotNull
+		RegistryKey<VillagerProfession> profession,
+		int level,
+		@NotNull
+		TradeOffers.Factory[] factories
+	) {
+		addToVillagerOfferPoolImpl(
+			profession, level, factories,
+			TradeOffersAccessor.quilt$getPROFESSION_TO_LEVELED_TRADE()
+		);
 	}
 
-	public static synchronized void registerWanderingTraderOffers(int level, Consumer<List<TradeOffers.Factory>> factory) {
-		registerOffers(TradeOffers.WANDERING_TRADER_TRADES, level, factory);
+	public static synchronized void addToExperimentalVillagerOfferPool(
+		@NotNull
+		RegistryKey<VillagerProfession> profession,
+		int level,
+		@NotNull
+		TradeOffers.Factory[] factories
+	) {
+		addToVillagerOfferPoolImpl(
+			profession, level, factories,
+			TradeOffersAccessor.quilt$getEXPERIMENTAL_TRADES()
+		);
 	}
 
-	// Shared code to register offers for both villagers and wandering traders.
-	private static void registerOffers(Int2ObjectMap<TradeOffers.Factory[]> leveledTradeMap, int level, Consumer<List<TradeOffers.Factory>> factory) {
-		final List<TradeOffers.Factory> list = new ArrayList<>();
-		factory.accept(list);
+	private static synchronized void addToVillagerOfferPoolImpl(
+		@NotNull
+		RegistryKey<VillagerProfession> profession,
+		int level,
+		@NotNull
+		TradeOffers.Factory[] factories, Map<RegistryKey<VillagerProfession>, Int2ObjectMap<TradeOffers.Factory[]>> tradesByProfession
+	) {
+		Objects.requireNonNull(profession, "profession must not be null");
 
-		final TradeOffers.Factory[] originalEntries = leveledTradeMap.computeIfAbsent(level, key -> new TradeOffers.Factory[0]);
-		final TradeOffers.Factory[] addedEntries = list.toArray(new TradeOffers.Factory[0]);
-
-		final TradeOffers.Factory[] allEntries = ArrayUtils.addAll(originalEntries, addedEntries);
-		leveledTradeMap.put(level, allEntries);
-	}
-
-	public static void printRefreshOffersWarning() {
-		Throwable loggingThrowable = new Throwable();
-		LOGGER.warn("TradeOfferHelper#refreshOffers does not do anything, yet it was called! Stack trace:", loggingThrowable);
-	}
-
-	public static class WanderingTraderOffersBuilderImpl implements TradeOfferHelper.WanderingTraderOffersBuilder {
-		private static final Object2IntMap<Identifier> ID_TO_INDEX = Util.make(new Object2IntOpenHashMap<>(), idToIndex -> {
-			idToIndex.put(BUY_ITEMS_POOL, 0);
-			idToIndex.put(SELL_SPECIAL_ITEMS_POOL, 1);
-			idToIndex.put(SELL_COMMON_ITEMS_POOL, 2);
-		});
-
-		private static final Map<Identifier, TradeOffers.Factory[]> DELAYED_MODIFICATIONS = new HashMap<>();
-
-		/**
-		 * Make the trade list modifiable.
-		 */
-		/*static void initWanderingTraderTrades() {
-			if (!(TradeOffers.WANDERING_TRADER_TRADES instanceof ArrayList)) {
-				TradeOffers.WANDERING_TRADER_TRADES = new ArrayList<>(TradeOffers.WANDERING_TRADER_TRADES);
-			}
-		}*/
-
-		@Override
-		public TradeOfferHelper.WanderingTraderOffersBuilder pool(Identifier id, int count, TradeOffers.Factory... factories) {
-			if (factories.length == 0) throw new IllegalArgumentException("cannot add empty pool");
-			if (count <= 0) throw new IllegalArgumentException("count must be positive");
-
-			Objects.requireNonNull(id, "id cannot be null");
-
-			if (ID_TO_INDEX.containsKey(id)) throw new IllegalArgumentException("pool id %s is already registered".formatted(id));
-
-			//initWanderingTraderTrades();
-			ID_TO_INDEX.put(id, count);
-			TradeOffers.WANDERING_TRADER_TRADES.put(count, factories);
-			TradeOffers.Factory[] delayedModifications = DELAYED_MODIFICATIONS.remove(id);
-
-			if (delayedModifications != null) addOffersToPool(id, delayedModifications);
-
-			return this;
+		if (level < 0) {
+			throw new IllegalArgumentException("level must not be negative; was:" + level);
 		}
 
-		@Override
-		public TradeOfferHelper.WanderingTraderOffersBuilder addOffersToPool(Identifier pool, TradeOffers.Factory... factories) {
-			if (!ID_TO_INDEX.containsKey(pool)) {
-				DELAYED_MODIFICATIONS.compute(pool, (id, current) -> {
-					if (current == null) return factories;
+		validateFactories(factories);
 
-					return ArrayUtils.addAll(current, factories);
-				});
-				return this;
+		final Int2ObjectMap<TradeOffers.Factory[]> leveledTradeMap = tradesByProfession
+			.computeIfAbsent(profession, key -> new Int2ObjectOpenHashMap<>());
+
+		final TradeOffers.Factory[] oldFactories =
+			leveledTradeMap.computeIfAbsent(level, key -> new TradeOffers.Factory[0]);
+
+        leveledTradeMap.put(level, ArrayUtils.addAll(oldFactories, factories));
+
+	}
+
+	public static synchronized void addToWanderingTraderOfferPool(
+		@NotNull
+		Identifier id,
+		@NotNull
+		TradeOffers.Factory[] factories
+	) {
+		validateId(id);
+		validateFactories(factories);
+
+		WanderingTraderOffersManager.getPool(id).ifPresentOrElse(
+			oldFactoriesAndCount -> {
+				final TradeOffers.Factory[] mergedFactories =
+					ArrayUtils.addAll(oldFactoriesAndCount.getLeft(), factories);
+				final Pair<TradeOffers.Factory[], Integer> mergedFactoriesAndCount =
+					Pair.of(mergedFactories, oldFactoriesAndCount.getRight());
+
+				WanderingTraderOffersManager.setPool(id, mergedFactoriesAndCount);
+			},
+			() -> {
+				PENDING_WANDERING_TRADER_FACTORIES_BY_ID.put(id, factories);
 			}
+		);
+	}
 
-			int poolIndex = ID_TO_INDEX.getInt(pool);
-			//initWanderingTraderTrades();
-			TradeOffers.Factory[] poolPair = TradeOffers.WANDERING_TRADER_TRADES.get(poolIndex);
-			TradeOffers.Factory[] modified = ArrayUtils.addAll(poolPair, factories);
-			TradeOffers.WANDERING_TRADER_TRADES.replace(poolIndex, modified);
-			return this;
+	public static synchronized void registerWanderingTraderPool(
+		@NotNull
+		Identifier id,
+		int count,
+		@NotNull
+		TradeOffers.Factory[] factories
+	) {
+		validateId(id);
+
+		if (count <= 0) {
+			throw new IllegalArgumentException("count must be greater than 0; was: " + count);
+		}
+
+		validateFactories(factories);
+
+		final Collection<TradeOffers.Factory[]> pendingFactories =
+			PENDING_WANDERING_TRADER_FACTORIES_BY_ID.removeAll(id);
+
+		final TradeOffers.Factory[] mergedFactories;
+		if (pendingFactories.isEmpty()) {
+			mergedFactories = factories;
+		} else {
+			mergedFactories = Stream
+				.concat(
+					Arrays.stream(factories),
+					pendingFactories.stream().flatMap(Arrays::stream)
+				)
+				.toArray(TradeOffers.Factory[]::new);
+		}
+
+		final Pair<TradeOffers.Factory[], Integer> factoriesAndCount = Pair.of(mergedFactories, count);
+
+		WanderingTraderOffersManager.registerPool(id, factoriesAndCount);
+	}
+
+	private static void validateId(@NotNull Identifier id) {
+		Objects.requireNonNull(id, "id must not be null");
+	}
+
+	private static void validateFactories(TradeOffers.Factory[] factories) {
+		if (Objects.requireNonNull(factories, "factories must not be null").length == 0) {
+			throw new IllegalArgumentException("factories must not be empty");
 		}
 	}
 }

--- a/library/entity/entity_extensions/src/main/java/org/quiltmc/qsl/entity/extensions/impl/TradeOfferInternals.java
+++ b/library/entity/entity_extensions/src/main/java/org/quiltmc/qsl/entity/extensions/impl/TradeOfferInternals.java
@@ -34,7 +34,6 @@ import net.minecraft.util.Identifier;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
-import org.quiltmc.qsl.entity.extensions.mixin.accessor.TradeOffersAccessor;
 
 import net.minecraft.village.TradeOffers;
 import net.minecraft.village.VillagerProfession;
@@ -60,7 +59,7 @@ public final class TradeOfferInternals {
 	) {
 		addToVillagerOfferPoolImpl(
 			profession, level, factories,
-			TradeOffersAccessor.quilt$getPROFESSION_TO_LEVELED_TRADE()
+			TradeOffers.PROFESSION_TO_LEVELED_TRADE
 		);
 	}
 
@@ -73,7 +72,7 @@ public final class TradeOfferInternals {
 	) {
 		addToVillagerOfferPoolImpl(
 			profession, level, factories,
-			TradeOffersAccessor.quilt$getEXPERIMENTAL_TRADES()
+			TradeOffers.EXPERIMENTAL_TRADES
 		);
 	}
 

--- a/library/entity/entity_extensions/src/main/java/org/quiltmc/qsl/entity/extensions/impl/WanderingTraderOffersManager.java
+++ b/library/entity/entity_extensions/src/main/java/org/quiltmc/qsl/entity/extensions/impl/WanderingTraderOffersManager.java
@@ -19,7 +19,9 @@ import static org.quiltmc.qsl.entity.extensions.api.TradeOfferHelper.VanillaWand
 import static org.quiltmc.qsl.entity.extensions.api.TradeOfferHelper.VanillaWanderingTraderPoolIds.SELL_COMMON_ITEMS;
 import static org.quiltmc.qsl.entity.extensions.api.TradeOfferHelper.VanillaWanderingTraderPoolIds.SELL_SPECIAL_ITEMS;
 
-// Methods to help keep WANDERING_TRADER_TRADES pool indexes and ids synchronized.
+/**
+ * Methods to help keep {@link TradeOffers#WANDERING_TRADER_TRADES} pool indexes and ids synchronized.
+ */
 @ApiStatus.Internal
 public class WanderingTraderOffersManager {
     private WanderingTraderOffersManager() {
@@ -35,7 +37,7 @@ public class WanderingTraderOffersManager {
     public static Optional<Pair<TradeOffers.Factory[], Integer>> getPool(Identifier id) {
         final int index = INDEXES_BY_ID.getOrDefault(id, -1);
         return index < 0 ? Optional.empty()
-            : Optional.of(TradeOffersAccessor.quilt$getWANDERING_TRADER_TRADES().get(index));
+            : Optional.of(TradeOffers.WANDERING_TRADER_TRADES.get(index));
     }
 
     public static void setPool(Identifier id, Pair<TradeOffers.Factory[], Integer> factoriesAndCount) {
@@ -60,7 +62,7 @@ public class WanderingTraderOffersManager {
 
     private static void mutateOffers(Consumer<List<Pair<TradeOffers.Factory[], Integer>>> mutator) {
         final List<Pair<TradeOffers.Factory[], Integer>> mutableOffers = new ArrayList<>(
-            TradeOffersAccessor.quilt$getWANDERING_TRADER_TRADES()
+            TradeOffers.WANDERING_TRADER_TRADES
         );
 
         mutator.accept(mutableOffers);

--- a/library/entity/entity_extensions/src/main/java/org/quiltmc/qsl/entity/extensions/impl/WanderingTraderOffersManager.java
+++ b/library/entity/entity_extensions/src/main/java/org/quiltmc/qsl/entity/extensions/impl/WanderingTraderOffersManager.java
@@ -1,0 +1,70 @@
+package org.quiltmc.qsl.entity.extensions.impl;
+
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import org.apache.commons.lang3.tuple.Pair;
+import org.jetbrains.annotations.ApiStatus;
+import org.quiltmc.qsl.entity.extensions.mixin.accessor.TradeOffersAccessor;
+
+import net.minecraft.util.Identifier;
+import net.minecraft.util.Util;
+import net.minecraft.village.TradeOffers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static org.quiltmc.qsl.entity.extensions.api.TradeOfferHelper.VanillaWanderingTraderPoolIds.BUY_ITEMS;
+import static org.quiltmc.qsl.entity.extensions.api.TradeOfferHelper.VanillaWanderingTraderPoolIds.SELL_COMMON_ITEMS;
+import static org.quiltmc.qsl.entity.extensions.api.TradeOfferHelper.VanillaWanderingTraderPoolIds.SELL_SPECIAL_ITEMS;
+
+// Methods to help keep WANDERING_TRADER_TRADES pool indexes and ids synchronized.
+@ApiStatus.Internal
+public class WanderingTraderOffersManager {
+    private WanderingTraderOffersManager() {
+        throw new UnsupportedOperationException("WanderingTraderOffersManager contains only static members");
+    }
+
+    private static final Object2IntMap<Identifier> INDEXES_BY_ID = Util.make(new Object2IntOpenHashMap<>(), map -> {
+        map.put(BUY_ITEMS, 0);
+        map.put(SELL_SPECIAL_ITEMS, 1);
+        map.put(SELL_COMMON_ITEMS, 2);
+    });
+
+    public static Optional<Pair<TradeOffers.Factory[], Integer>> getPool(Identifier id) {
+        final int index = INDEXES_BY_ID.getOrDefault(id, -1);
+        return index < 0 ? Optional.empty()
+            : Optional.of(TradeOffersAccessor.quilt$getWANDERING_TRADER_TRADES().get(index));
+    }
+
+    public static void setPool(Identifier id, Pair<TradeOffers.Factory[], Integer> factoriesAndCount) {
+        final int index = INDEXES_BY_ID.getOrDefault(id, -1);
+        if (index < 0) {
+            throw new IllegalArgumentException("no pool with id: " + id);
+        } else {
+            mutateOffers(offers -> offers.set(index, factoriesAndCount));
+        }
+    }
+
+    public static void registerPool(Identifier id, Pair<TradeOffers.Factory[], Integer> factoriesAndCount) {
+        if (INDEXES_BY_ID.getOrDefault(id, -1) < 0) {
+            throw new IllegalArgumentException("pool id %s is already registered".formatted(id));
+        } else {
+            mutateOffers(offers -> {
+                INDEXES_BY_ID.put(id, offers.size());
+                offers.add(factoriesAndCount);
+            });
+        }
+    }
+
+    private static void mutateOffers(Consumer<List<Pair<TradeOffers.Factory[], Integer>>> mutator) {
+        final List<Pair<TradeOffers.Factory[], Integer>> mutableOffers = new ArrayList<>(
+            TradeOffersAccessor.quilt$getWANDERING_TRADER_TRADES()
+        );
+
+        mutator.accept(mutableOffers);
+
+        TradeOffersAccessor.quilt$setWANDERING_TRADER_TRADES(mutableOffers);
+    }
+}

--- a/library/entity/entity_extensions/src/main/java/org/quiltmc/qsl/entity/extensions/mixin/DetectorRailBlockMixin.java
+++ b/library/entity/entity_extensions/src/main/java/org/quiltmc/qsl/entity/extensions/mixin/DetectorRailBlockMixin.java
@@ -37,19 +37,25 @@ import net.minecraft.world.World;
 import org.quiltmc.qsl.entity.extensions.api.MinecartComparatorLogic;
 
 @Mixin(DetectorRailBlock.class)
-public abstract class DetectorRailBlockMixin {
+abstract class DetectorRailBlockMixin {
 	@Shadow
-	protected abstract <T extends AbstractMinecartEntity> List<T> getCarts(World world, BlockPos pos, Class<T> entityClass, @Nullable Predicate<Entity> entityPredicate);
+	protected abstract <T extends AbstractMinecartEntity> List<T> getCarts(
+		World world, BlockPos pos, Class<T> entityClass, @Nullable Predicate<Entity> entityPredicate
+	);
 
 	@Inject(at = @At("HEAD"), method = "getComparatorOutput", cancellable = true)
-	private void getCustomComparatorOutput(BlockState state, World world, BlockPos pos, CallbackInfoReturnable<Integer> cir) {
+	private void getCustomComparatorOutput(
+		BlockState state, World world, BlockPos pos, CallbackInfoReturnable<Integer> cir
+	) {
 		if (state.getOrDefault(DetectorRailBlock.POWERED, false)) {
-			List<AbstractMinecartEntity> carts = this.getCarts(world, pos, AbstractMinecartEntity.class,
-					cart -> ((MinecartComparatorLogic) cart).getComparatorValue(state, pos) >= 0);
-
-			if (carts.isEmpty()) return;
-
-			cir.setReturnValue(carts.get(0).getComparatorValue(state, pos));
+			this
+				.getCarts(
+					world, pos, AbstractMinecartEntity.class,
+					cart -> ((MinecartComparatorLogic) cart).getComparatorValue(state, pos) >= 0
+				)
+				.stream()
+				.findFirst()
+				.ifPresent(cart -> cir.setReturnValue(cart.getComparatorValue(state, pos)));
 		}
 	}
 }

--- a/library/entity/entity_extensions/src/main/java/org/quiltmc/qsl/entity/extensions/mixin/TypeAwareBuyForOneEmeraldFactoryMixin.java
+++ b/library/entity/entity_extensions/src/main/java/org/quiltmc/qsl/entity/extensions/mixin/TypeAwareBuyForOneEmeraldFactoryMixin.java
@@ -17,6 +17,7 @@
 
 package org.quiltmc.qsl.entity.extensions.mixin;
 
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.spongepowered.asm.mixin.Mixin;
@@ -24,15 +25,14 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import net.minecraft.entity.Entity;
-import net.minecraft.registry.DefaultedRegistry;
 import net.minecraft.util.random.RandomGenerator;
 import net.minecraft.village.TradeOffer;
 import net.minecraft.village.TradeOffers;
 import net.minecraft.village.TradeableItem;
-import net.minecraft.village.VillagerDataContainer;
+
+import com.llamalad7.mixinextras.sugar.Local;
 
 @Mixin(TradeOffers.TypeAwareBuyForOneEmeraldFactory.class)
 public abstract class TypeAwareBuyForOneEmeraldFactoryMixin {
@@ -42,8 +42,8 @@ public abstract class TypeAwareBuyForOneEmeraldFactoryMixin {
 	 * We want to prevent this default logic so modded villager types will work.
 	 * So we return an empty stream so an exception is never thrown.
 	 */
-	@Redirect(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/registry/DefaultedRegistry;stream()Ljava/util/stream/Stream;"))
-	private <T> Stream<T> disableVanillaCheck(DefaultedRegistry<T> registry) {
+	@Redirect(method = "<init>", at = @At(value = "INVOKE", target = "Ljava/util/Set;stream()Ljava/util/stream/Stream;"))
+	private <T> Stream<T> disableVanillaCheck(Set<?> instance) {
 		return Stream.empty();
 	}
 
@@ -54,14 +54,19 @@ public abstract class TypeAwareBuyForOneEmeraldFactoryMixin {
 			method = "create",
 			at = @At(
 				value = "NEW",
-				target = "(Lnet/minecraft/village/TradeableItem;Lnet/minecraft/item/ItemStack;IIF)Lnet/minecraft/village/TradeOffer;"
+				target = "(Lnet/minecraft/village/TradeableItem;Lnet/minecraft/item/ItemStack;IIF)" +
+					"Lnet/minecraft/village/TradeOffer;"
 			),
-			locals = LocalCapture.CAPTURE_FAILEXCEPTION,
 			cancellable = true
 	)
-	private void failOnNullItem(Entity entity, RandomGenerator random, CallbackInfoReturnable<TradeOffer> cir, VillagerDataContainer villagerDataContainer, TradeableItem buyingItem) {
-		if (buyingItem.count() == 0 || buyingItem.itemStack().isEmpty()) { // Will return true for an "empty" item stack that had null passed in the ctor
-			cir.setReturnValue(null); // Return null to prevent creation of empty trades
+	private void failOnNullItem(
+		Entity entity, RandomGenerator random, CallbackInfoReturnable<TradeOffer> cir,
+		@Local TradeableItem buyingItem
+	) {
+		// Will return true for an "empty" item stack that had null passed in the ctor
+		if (buyingItem.count() == 0 || buyingItem.itemStack().isEmpty()) {
+			// Return null to prevent creation of empty trades
+			cir.setReturnValue(null);
 		}
 	}
 }

--- a/library/entity/entity_extensions/src/main/java/org/quiltmc/qsl/entity/extensions/mixin/accessor/TradeOffersAccessor.java
+++ b/library/entity/entity_extensions/src/main/java/org/quiltmc/qsl/entity/extensions/mixin/accessor/TradeOffersAccessor.java
@@ -1,46 +1,24 @@
 package org.quiltmc.qsl.entity.extensions.mixin.accessor;
 
-import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import org.apache.commons.lang3.tuple.Pair;
 import org.quiltmc.qsl.entity.extensions.impl.WanderingTraderOffersManager;
 
-import net.minecraft.registry.RegistryKey;
 import net.minecraft.village.TradeOffers;
-import net.minecraft.village.VillagerProfession;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
 import java.util.List;
-import java.util.Map;
 
 @Mixin(TradeOffers.class)
 public interface TradeOffersAccessor {
     /**
      * Only for use in {@link WanderingTraderOffersManager}
      */
-    @Accessor("WANDERING_TRADER_TRADES")
-    static List<Pair<TradeOffers.Factory[], Integer>> quilt$getWANDERING_TRADER_TRADES() {
-        throw new AssertionError("dummy method body reached");
-    }
-
-    /**
-     * Only for use in {@link WanderingTraderOffersManager}
-     */
+    @Mutable
     @Accessor("WANDERING_TRADER_TRADES")
     static void quilt$setWANDERING_TRADER_TRADES(List<Pair<TradeOffers.Factory[], Integer>> trades) {
-        throw new AssertionError("dummy method body reached");
-    }
-
-    @Accessor("PROFESSION_TO_LEVELED_TRADE")
-    static Map<RegistryKey<VillagerProfession>, Int2ObjectMap<TradeOffers.Factory[]>>
-    quilt$getPROFESSION_TO_LEVELED_TRADE() {
-        throw new AssertionError("dummy method body reached");
-    }
-
-    @Accessor("EXPERIMENTAL_TRADES")
-    static Map<RegistryKey<VillagerProfession>, Int2ObjectMap<TradeOffers.Factory[]>>
-    quilt$getEXPERIMENTAL_TRADES() {
         throw new AssertionError("dummy method body reached");
     }
 }

--- a/library/entity/entity_extensions/src/main/java/org/quiltmc/qsl/entity/extensions/mixin/accessor/TradeOffersAccessor.java
+++ b/library/entity/entity_extensions/src/main/java/org/quiltmc/qsl/entity/extensions/mixin/accessor/TradeOffersAccessor.java
@@ -1,0 +1,46 @@
+package org.quiltmc.qsl.entity.extensions.mixin.accessor;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import org.apache.commons.lang3.tuple.Pair;
+import org.quiltmc.qsl.entity.extensions.impl.WanderingTraderOffersManager;
+
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.village.TradeOffers;
+import net.minecraft.village.VillagerProfession;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.List;
+import java.util.Map;
+
+@Mixin(TradeOffers.class)
+public interface TradeOffersAccessor {
+    /**
+     * Only for use in {@link WanderingTraderOffersManager}
+     */
+    @Accessor("WANDERING_TRADER_TRADES")
+    static List<Pair<TradeOffers.Factory[], Integer>> quilt$getWANDERING_TRADER_TRADES() {
+        throw new AssertionError("dummy method body reached");
+    }
+
+    /**
+     * Only for use in {@link WanderingTraderOffersManager}
+     */
+    @Accessor("WANDERING_TRADER_TRADES")
+    static void quilt$setWANDERING_TRADER_TRADES(List<Pair<TradeOffers.Factory[], Integer>> trades) {
+        throw new AssertionError("dummy method body reached");
+    }
+
+    @Accessor("PROFESSION_TO_LEVELED_TRADE")
+    static Map<RegistryKey<VillagerProfession>, Int2ObjectMap<TradeOffers.Factory[]>>
+    quilt$getPROFESSION_TO_LEVELED_TRADE() {
+        throw new AssertionError("dummy method body reached");
+    }
+
+    @Accessor("EXPERIMENTAL_TRADES")
+    static Map<RegistryKey<VillagerProfession>, Int2ObjectMap<TradeOffers.Factory[]>>
+    quilt$getEXPERIMENTAL_TRADES() {
+        throw new AssertionError("dummy method body reached");
+    }
+}

--- a/library/entity/entity_extensions/src/main/resources/quilt_entity_extensions.accesswidener
+++ b/library/entity/entity_extensions/src/main/resources/quilt_entity_extensions.accesswidener
@@ -19,5 +19,3 @@ transitive-accessible  class   net/minecraft/village/TradeOffers$TypeAwareBuyFor
 
 # Internal Villager AWs
 accessible class net/minecraft/village/TradeOffers$TypeAwareBuyForOneEmeraldFactory
-mutable field net/minecraft/village/TradeOffers PROFESSION_TO_LEVELED_TRADE Ljava/util/Map;
-mutable field net/minecraft/village/TradeOffers WANDERING_TRADER_TRADES     Ljava/util/List;

--- a/library/entity/entity_extensions/src/main/resources/quilt_entity_extensions.mixins.json
+++ b/library/entity/entity_extensions/src/main/resources/quilt_entity_extensions.mixins.json
@@ -9,6 +9,7 @@
     "PointOfInterestTypeMixin",
     "PointOfInterestTypesAccessor",
     "TypeAwareBuyForOneEmeraldFactoryMixin",
+    "accessor.TradeOffersAccessor",
     "networking.EntityMixin",
     "networking.TrackedDataHandlerRegistryMixin"
   ],

--- a/library/entity/entity_extensions/src/testmod/java/org/quiltmc/qsl/entity/test/mixin/networking/CreeperEntityMixin.java
+++ b/library/entity/entity_extensions/src/testmod/java/org/quiltmc/qsl/entity/test/mixin/networking/CreeperEntityMixin.java
@@ -23,40 +23,43 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import net.minecraft.entity.EntityType;
 import net.minecraft.entity.data.DataTracker;
 import net.minecraft.entity.data.TrackedData;
 import net.minecraft.entity.data.TrackedDataHandlerRegistry;
 import net.minecraft.entity.mob.CreeperEntity;
 import net.minecraft.entity.mob.HostileEntity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.network.RegistryByteBuf;
 import net.minecraft.particle.ParticleEffect;
 import net.minecraft.particle.ParticleTypes;
 import net.minecraft.registry.Registries;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
-import net.minecraft.world.World;
 
 import org.quiltmc.qsl.entity.extensions.api.networking.QuiltExtendedSpawnDataEntity;
 import org.quiltmc.qsl.entity.test.networking.CreeperWithItem;
-import org.quiltmc.qsl.entity.test.networking.TrackedDataTestInitializer;
 
 /**
  * In actual mods, do not add tracked data to existing entities, and do not replace spawn packets.
  * This is purely for testing QSL easily.
  */
 @Mixin(CreeperEntity.class)
-public class CreeperEntityMixin extends HostileEntity implements QuiltExtendedSpawnDataEntity, CreeperWithItem {
+abstract class CreeperEntityMixin extends HostileEntity implements QuiltExtendedSpawnDataEntity, CreeperWithItem {
 	// Make creepers store a particle effect to test a custom tracked data handler
 
 	@SuppressWarnings("WrongEntityDataParameterClass")
-	private static final TrackedData<ParticleEffect> PARTICLE = DataTracker.registerData(CreeperEntity.class, TrackedDataHandlerRegistry.PARTICLE);
+	@Unique
+	private static final TrackedData<ParticleEffect> PARTICLE = DataTracker
+		.registerData(CreeperEntity.class, TrackedDataHandlerRegistry.PARTICLE);
 
-	protected CreeperEntityMixin(EntityType<? extends HostileEntity> entityType, World world) {
-		super(entityType, world);
+	@SuppressWarnings("DataFlowIssue")
+    private CreeperEntityMixin() {
+		super(null, null);
+		throw new AssertionError("dummy constructor called");
 	}
 
 	@Inject(method = "initDataTracker", at = @At("TAIL"))
@@ -80,33 +83,33 @@ public class CreeperEntityMixin extends HostileEntity implements QuiltExtendedSp
 	// Make creepers drop a random item on explosion and render it over their head to test extended spawn data
 
 	@Unique
-	private ItemStack quilt$stackToDrop;
+	private ItemStack stackToDrop;
 
 	@Inject(method = "<init>", at = @At("TAIL"))
-	private void quiltTestMod$storeRandomItem(CallbackInfo ci) {
-		var random = Registries.ITEM.getRandom(this.random).get().value();
-		this.quilt$stackToDrop = new ItemStack(random);
+	private void storeRandomItem(CallbackInfo ci) {
+        final Item random = Registries.ITEM.getRandom(this.random).orElseThrow().getValue();
+		this.stackToDrop = new ItemStack(random);
 	}
 
 	@Inject(method = "explode", at = @At("TAIL"))
-	private void quiltTestMod$dropItemOnExplosion(CallbackInfo ci) {
-		if (!this.getWorld().isClient) {
-			dropStack(this.quilt$stackToDrop);
+	private void dropItemOnExplosion(CallbackInfo ci) {
+		if (this.getWorld() instanceof ServerWorld world) {
+            this.dropStack(world, this.stackToDrop);
 		}
 	}
 
 	@Override
 	public void writeAdditionalSpawnData(RegistryByteBuf buffer) {
-		ItemStack.PACKET_CODEC.encode(buffer, this.quilt$stackToDrop);
+		ItemStack.PACKET_CODEC.encode(buffer, this.stackToDrop);
 	}
 
 	@Override
 	public void readAdditionalSpawnData(RegistryByteBuf buffer) {
-		this.quilt$stackToDrop = ItemStack.PACKET_CODEC.decode(buffer);
+		this.stackToDrop = ItemStack.PACKET_CODEC.decode(buffer);
 	}
 
 	@Override
-	public ItemStack getStack() {
-		return this.quilt$stackToDrop;
+	public ItemStack quilt$getStack() {
+		return this.stackToDrop;
 	}
 }

--- a/library/entity/entity_extensions/src/testmod/java/org/quiltmc/qsl/entity/test/mixin/networking/CreeperEntityRendererMixin.java
+++ b/library/entity/entity_extensions/src/testmod/java/org/quiltmc/qsl/entity/test/mixin/networking/CreeperEntityRendererMixin.java
@@ -16,44 +16,64 @@
 
 package org.quiltmc.qsl.entity.test.mixin.networking;
 
+import org.quiltmc.qsl.entity.test.networking.CreeperStateWithItem;
 import org.quiltmc.qsl.entity.test.networking.CreeperWithItem;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.OverlayTexture;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.entity.CreeperEntityRenderer;
-import net.minecraft.client.render.entity.EntityRendererFactory.Context;
 import net.minecraft.client.render.entity.MobEntityRenderer;
 import net.minecraft.client.render.entity.model.CreeperEntityModel;
+import net.minecraft.client.render.entity.state.CreeperRenderState;
 import net.minecraft.client.render.model.json.ModelTransformationMode;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.mob.CreeperEntity;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.Axis;
 
 @Mixin(CreeperEntityRenderer.class)
-public abstract class CreeperEntityRendererMixin extends MobEntityRenderer<CreeperEntity, CreeperEntityModel<CreeperEntity>> {
-	public CreeperEntityRendererMixin(Context context, CreeperEntityModel<CreeperEntity> entityModel, float f) {
-		super(context, entityModel, f);
+abstract class CreeperEntityRendererMixin extends MobEntityRenderer<CreeperEntity, CreeperRenderState, CreeperEntityModel> {
+	@SuppressWarnings("DataFlowIssue")
+    private CreeperEntityRendererMixin() {
+		super(null, null, 0);
+		throw new AssertionError("dummy constructor called");
 	}
 
 	@Override
-	public void render(CreeperEntity creeper, float yaw, float tickDelta, MatrixStack matrixStack,
-					   VertexConsumerProvider vertexConsumerProvider, int light) {
-		super.render(creeper, yaw, tickDelta, matrixStack, vertexConsumerProvider, light);
+	public void render(CreeperRenderState state, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light) {
+		super.render(state, matrices, vertexConsumers, light);
 
-		float rotation = (creeper.age + tickDelta) / 20;
-		var stack = ((CreeperWithItem) creeper).getStack();
-		var itemRenderer = MinecraftClient.getInstance().getItemRenderer();
+		final CreeperStateWithItem extendedState = (CreeperStateWithItem) state;
+		final float rotation = extendedState.quilt$getStackRotation();
+        final ItemStack stack = extendedState.quilt$getStack();
 
-		matrixStack.push();
-		matrixStack.translate(0, 2, 0);
-		matrixStack.scale(0.25f, 0.25f, 0.25f);
-		matrixStack.rotate(Axis.Y_POSITIVE.rotation(rotation));
-		itemRenderer.renderItem(
-				stack, ModelTransformationMode.NONE, light, OverlayTexture.DEFAULT_UV,
-				matrixStack, vertexConsumerProvider, creeper.getWorld(), 0
+        matrices.push();
+		matrices.translate(0, 2, 0);
+		matrices.scale(0.25f, 0.25f, 0.25f);
+		// method_22907 is rotate
+		matrices.method_22907(Axis.Y_POSITIVE.rotation(rotation));
+		MinecraftClient.getInstance().getItemRenderer().renderItem(
+			stack, ModelTransformationMode.NONE, light, OverlayTexture.DEFAULT_UV,
+			matrices, vertexConsumers, null, 0
 		);
-		matrixStack.pop();
+		matrices.pop();
+	}
+
+	@Inject(
+		method = "updateState(Lnet/minecraft/entity/mob/CreeperEntity;" +
+			"Lnet/minecraft/client/render/entity/state/CreeperRenderState;F)V",
+		at = @At("TAIL")
+	)
+	private void updateStack(
+		CreeperEntity creeper, CreeperRenderState state, float tickDelta, CallbackInfo ci
+	) {
+		final CreeperStateWithItem extendedState = (CreeperStateWithItem) state;
+		extendedState.quilt$setStack(((CreeperWithItem) creeper).quilt$getStack());
+		extendedState.quilt$setStackRotation((state.age + tickDelta) / 20);
 	}
 }

--- a/library/entity/entity_extensions/src/testmod/java/org/quiltmc/qsl/entity/test/mixin/networking/CreeperRenderStateMixin.java
+++ b/library/entity/entity_extensions/src/testmod/java/org/quiltmc/qsl/entity/test/mixin/networking/CreeperRenderStateMixin.java
@@ -1,0 +1,38 @@
+package org.quiltmc.qsl.entity.test.mixin.networking;
+
+import org.quiltmc.qsl.entity.test.networking.CreeperStateWithItem;
+
+import net.minecraft.client.render.entity.state.CreeperRenderState;
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(CreeperRenderState.class)
+abstract class CreeperRenderStateMixin implements CreeperStateWithItem {
+    @Unique
+    private ItemStack stackToDrop;
+
+    @Unique
+    private float stackRotation;
+
+    @Override
+    public ItemStack quilt$getStack() {
+        return this.stackToDrop;
+    }
+
+    @Override
+    public void quilt$setStack(ItemStack stack) {
+        this.stackToDrop = stack;
+    }
+
+    @Override
+    public float quilt$getStackRotation() {
+        return this.stackRotation;
+    }
+
+    @Override
+    public void quilt$setStackRotation(float rotation) {
+        this.stackRotation = rotation;
+    }
+}

--- a/library/entity/entity_extensions/src/testmod/java/org/quiltmc/qsl/entity/test/networking/CreeperStateWithItem.java
+++ b/library/entity/entity_extensions/src/testmod/java/org/quiltmc/qsl/entity/test/networking/CreeperStateWithItem.java
@@ -1,0 +1,13 @@
+package org.quiltmc.qsl.entity.test.networking;
+
+import net.minecraft.item.ItemStack;
+
+public interface CreeperStateWithItem {
+    ItemStack quilt$getStack();
+
+    void quilt$setStack(ItemStack stack);
+
+    float quilt$getStackRotation();
+
+    void quilt$setStackRotation(float rotation);
+}

--- a/library/entity/entity_extensions/src/testmod/java/org/quiltmc/qsl/entity/test/networking/CreeperWithItem.java
+++ b/library/entity/entity_extensions/src/testmod/java/org/quiltmc/qsl/entity/test/networking/CreeperWithItem.java
@@ -19,5 +19,5 @@ package org.quiltmc.qsl.entity.test.networking;
 import net.minecraft.item.ItemStack;
 
 public interface CreeperWithItem {
-	ItemStack getStack();
+	ItemStack quilt$getStack();
 }

--- a/library/entity/entity_extensions/src/testmod/java/org/quiltmc/qsl/entity/test/villager/VillagerTypeTest1.java
+++ b/library/entity/entity_extensions/src/testmod/java/org/quiltmc/qsl/entity/test/villager/VillagerTypeTest1.java
@@ -32,7 +32,7 @@ import org.quiltmc.qsl.entity.extensions.api.TradeOfferHelper;
 public class VillagerTypeTest1 implements ModInitializer {
 	@Override
 	public void onInitialize(ModContainer mod) {
-		TradeOfferHelper.registerVillagerOffers(VillagerProfession.ARMORER, 1, factories -> {
+		TradeOfferHelper.addOffersToVillagerPool(VillagerProfession.ARMORER, 1, factories -> {
 			factories.add(new SimpleTradeFactory(new TradeOffer(new TradeableItem(Items.GOLD_INGOT, 3), Optional.of(new TradeableItem(Items.NETHERITE_SCRAP, 4)), new ItemStack(Items.NETHERITE_INGOT), 2, 6, 0.15F)));
 		});
 

--- a/library/entity/entity_extensions/src/testmod/java/org/quiltmc/qsl/entity/test/villager/VillagerTypeTest1.java
+++ b/library/entity/entity_extensions/src/testmod/java/org/quiltmc/qsl/entity/test/villager/VillagerTypeTest1.java
@@ -17,6 +17,7 @@
 
 package org.quiltmc.qsl.entity.test.villager;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import net.minecraft.item.ItemStack;
@@ -32,12 +33,28 @@ import org.quiltmc.qsl.entity.extensions.api.TradeOfferHelper;
 public class VillagerTypeTest1 implements ModInitializer {
 	@Override
 	public void onInitialize(ModContainer mod) {
-		TradeOfferHelper.addOffersToVillagerPool(VillagerProfession.ARMORER, 1, factories -> {
-			factories.add(new SimpleTradeFactory(new TradeOffer(new TradeableItem(Items.GOLD_INGOT, 3), Optional.of(new TradeableItem(Items.NETHERITE_SCRAP, 4)), new ItemStack(Items.NETHERITE_INGOT), 2, 6, 0.15F)));
-		});
+		TradeOfferHelper.addToVillagerOfferPool(
+			VillagerProfession.ARMORER, 1,
+			new SimpleTradeFactory(new TradeOffer(
+				new TradeableItem(Items.GOLD_INGOT, 3),
+				Optional.of(new TradeableItem(Items.NETHERITE_SCRAP, 4)),
+				new ItemStack(Items.NETHERITE_INGOT),
+				2, 6, 0.15F
+			))
+		);
 
-		TradeOfferHelper.registerWanderingTraderOffers(1, factories -> {
-			factories.add(new SimpleTradeFactory(new TradeOffer(new TradeableItem(Items.GOLD_INGOT, 3), Optional.of(new TradeableItem(Items.NETHERITE_SCRAP, 4)), new ItemStack(Items.NETHERITE_INGOT), 2, 6, 0.35F)));
-		});
+        TradeOfferHelper.addToWanderingTraderOfferPool(
+			TradeOfferHelper.VanillaWanderingTraderPoolIds.SELL_SPECIAL_ITEMS,
+			// 100 copies to make it more likely
+			Collections.nCopies(
+				100,
+				new SimpleTradeFactory(new TradeOffer(
+					new TradeableItem(Items.GOLD_INGOT, 3),
+					Optional.of(new TradeableItem(Items.NETHERITE_SCRAP, 4)),
+					new ItemStack(Items.NETHERITE_INGOT),
+					2, 6, 0.35F
+				))
+			)
+		);
 	}
 }

--- a/library/entity/entity_extensions/src/testmod/java/org/quiltmc/qsl/entity/test/villager/VillagerTypeTest2.java
+++ b/library/entity/entity_extensions/src/testmod/java/org/quiltmc/qsl/entity/test/villager/VillagerTypeTest2.java
@@ -33,22 +33,22 @@ import org.quiltmc.qsl.entity.extensions.api.TradeOfferHelper;
 public class VillagerTypeTest2 implements ModInitializer {
 	@Override
 	public void onInitialize(ModContainer mod) {
-		TradeOfferHelper.registerVillagerOffers(VillagerProfession.ARMORER, 1, factories -> {
+		TradeOfferHelper.addOffersToVillagerPool(VillagerProfession.ARMORER, 1, factories -> {
 			factories.add(new SimpleTradeFactory(new TradeOffer(new TradeableItem(Items.DIAMOND, 5), new ItemStack(Items.NETHERITE_INGOT), 3, 4, 0.15F)));
 		});
-		TradeOfferHelper.registerVillagerOffers(VillagerProfession.ARMORER, 1, factories -> {
+		TradeOfferHelper.addOffersToVillagerPool(VillagerProfession.ARMORER, 1, factories -> {
 			factories.add(new SimpleTradeFactory(new TradeOffer(new TradeableItem(Items.DIAMOND, 6), new ItemStack(Items.ELYTRA), 3, 4, 0.15F)));
 		});
-		TradeOfferHelper.registerVillagerOffers(VillagerProfession.ARMORER, 1, factories -> {
+		TradeOfferHelper.addOffersToVillagerPool(VillagerProfession.ARMORER, 1, factories -> {
 			factories.add(new SimpleTradeFactory(new TradeOffer(new TradeableItem(Items.DIAMOND, 7), new ItemStack(Items.CHAINMAIL_BOOTS), 3, 4, 0.15F)));
 		});
-		TradeOfferHelper.registerVillagerOffers(VillagerProfession.ARMORER, 1, factories -> {
+		TradeOfferHelper.addOffersToVillagerPool(VillagerProfession.ARMORER, 1, factories -> {
 			factories.add(new SimpleTradeFactory(new TradeOffer(new TradeableItem(Items.DIAMOND, 8), new ItemStack(Items.CHAINMAIL_CHESTPLATE), 3, 4, 0.15F)));
 		});
-		TradeOfferHelper.registerVillagerOffers(VillagerProfession.ARMORER, 1, factories -> {
+		TradeOfferHelper.addOffersToVillagerPool(VillagerProfession.ARMORER, 1, factories -> {
 			factories.add(new SimpleTradeFactory(new TradeOffer(new TradeableItem(Items.DIAMOND, 9), new ItemStack(Items.CHAINMAIL_HELMET), 3, 4, 0.15F)));
 		});
-		TradeOfferHelper.registerVillagerOffers(VillagerProfession.ARMORER, 1, factories -> {
+		TradeOfferHelper.addOffersToVillagerPool(VillagerProfession.ARMORER, 1, factories -> {
 			factories.add(new SimpleTradeFactory(new TradeOffer(new TradeableItem(Items.DIAMOND, 10), new ItemStack(Items.CHAINMAIL_LEGGINGS), 3, 4, 0.15F)));
 		});
 	}

--- a/library/entity/entity_extensions/src/testmod/java/org/quiltmc/qsl/entity/test/villager/VillagerTypeTest2.java
+++ b/library/entity/entity_extensions/src/testmod/java/org/quiltmc/qsl/entity/test/villager/VillagerTypeTest2.java
@@ -33,23 +33,58 @@ import org.quiltmc.qsl.entity.extensions.api.TradeOfferHelper;
 public class VillagerTypeTest2 implements ModInitializer {
 	@Override
 	public void onInitialize(ModContainer mod) {
-		TradeOfferHelper.addOffersToVillagerPool(VillagerProfession.ARMORER, 1, factories -> {
-			factories.add(new SimpleTradeFactory(new TradeOffer(new TradeableItem(Items.DIAMOND, 5), new ItemStack(Items.NETHERITE_INGOT), 3, 4, 0.15F)));
-		});
-		TradeOfferHelper.addOffersToVillagerPool(VillagerProfession.ARMORER, 1, factories -> {
-			factories.add(new SimpleTradeFactory(new TradeOffer(new TradeableItem(Items.DIAMOND, 6), new ItemStack(Items.ELYTRA), 3, 4, 0.15F)));
-		});
-		TradeOfferHelper.addOffersToVillagerPool(VillagerProfession.ARMORER, 1, factories -> {
-			factories.add(new SimpleTradeFactory(new TradeOffer(new TradeableItem(Items.DIAMOND, 7), new ItemStack(Items.CHAINMAIL_BOOTS), 3, 4, 0.15F)));
-		});
-		TradeOfferHelper.addOffersToVillagerPool(VillagerProfession.ARMORER, 1, factories -> {
-			factories.add(new SimpleTradeFactory(new TradeOffer(new TradeableItem(Items.DIAMOND, 8), new ItemStack(Items.CHAINMAIL_CHESTPLATE), 3, 4, 0.15F)));
-		});
-		TradeOfferHelper.addOffersToVillagerPool(VillagerProfession.ARMORER, 1, factories -> {
-			factories.add(new SimpleTradeFactory(new TradeOffer(new TradeableItem(Items.DIAMOND, 9), new ItemStack(Items.CHAINMAIL_HELMET), 3, 4, 0.15F)));
-		});
-		TradeOfferHelper.addOffersToVillagerPool(VillagerProfession.ARMORER, 1, factories -> {
-			factories.add(new SimpleTradeFactory(new TradeOffer(new TradeableItem(Items.DIAMOND, 10), new ItemStack(Items.CHAINMAIL_LEGGINGS), 3, 4, 0.15F)));
-		});
+		TradeOfferHelper.addToVillagerOfferPool(
+			VillagerProfession.ARMORER, 1,
+			new SimpleTradeFactory(new TradeOffer(
+				new TradeableItem(Items.DIAMOND, 5),
+				new ItemStack(Items.NETHERITE_INGOT),
+				3, 4, 0.15F
+			))
+		);
+
+		TradeOfferHelper.addToVillagerOfferPool(
+			VillagerProfession.ARMORER, 1,
+			new SimpleTradeFactory(new TradeOffer(
+				new TradeableItem(Items.DIAMOND, 6),
+				new ItemStack(Items.ELYTRA),
+				3, 4, 0.15F
+			))
+		);
+
+		TradeOfferHelper.addToVillagerOfferPool(
+			VillagerProfession.ARMORER, 1,
+			new SimpleTradeFactory(new TradeOffer(
+				new TradeableItem(Items.DIAMOND, 7),
+				new ItemStack(Items.CHAINMAIL_BOOTS),
+				3, 4, 0.15F
+			))
+		);
+
+		TradeOfferHelper.addToVillagerOfferPool(
+			VillagerProfession.ARMORER, 1,
+			new SimpleTradeFactory(new TradeOffer(
+				new TradeableItem(Items.DIAMOND, 8),
+				new ItemStack(Items.CHAINMAIL_CHESTPLATE),
+				3, 4, 0.15F
+			))
+		);
+
+		TradeOfferHelper.addToVillagerOfferPool(
+			VillagerProfession.ARMORER, 1,
+			new SimpleTradeFactory(new TradeOffer(
+				new TradeableItem(Items.DIAMOND, 9),
+				new ItemStack(Items.CHAINMAIL_HELMET),
+				3, 4, 0.15F
+			))
+		);
+
+		TradeOfferHelper.addToVillagerOfferPool(
+			VillagerProfession.ARMORER, 1,
+			new SimpleTradeFactory(new TradeOffer(
+				new TradeableItem(Items.DIAMOND, 10),
+				new ItemStack(Items.CHAINMAIL_LEGGINGS),
+				3, 4, 0.15F
+			))
+		);
 	}
 }

--- a/library/entity/entity_extensions/src/testmod/resources/quilt_entity_test.mixins.json
+++ b/library/entity/entity_extensions/src/testmod/resources/quilt_entity_test.mixins.json
@@ -3,11 +3,12 @@
   "package": "org.quiltmc.qsl.entity.test.mixin",
   "compatibilityLevel": "JAVA_17",
   "client": [
-    "networking.CreeperEntityRendererMixin"
+    "networking.CreeperEntityRendererMixin",
+    "networking.CreeperRenderStateMixin"
   ],
   "mixins": [
-    "networking.CreeperEntityMixin",
-    "TntMinecartEntityMixin"
+    "TntMinecartEntityMixin",
+    "networking.CreeperEntityMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
- reworks the trade offer api to avoid use of unnecessary `Consumer`s
- flattens the functionality of `WanderingTraderOffersBuilder` into static methods
- fixes the rest of `entity_extensions`