### PR TITLE
`entity_events` and `block_entity` fixes

### DIFF
--- a/library/block/block_entity/build.gradle
+++ b/library/block/block_entity/build.gradle
@@ -17,6 +17,11 @@ qslModule {
 		block {
 			testmodOnly("block_extensions")
 		}
+		gui {
+			// FIXME this shouldn't be necessary since resource_loader already depends on it,
+			//  but it's not actually present for the testmod for some reason
+			testmodOnly("screen")
+		}
 	}
 	entrypoints {
 		init {

--- a/library/block/block_entity/src/main/java/org/quiltmc/qsl/block/entity/api/QuiltBlockEntityTypeBuilder.java
+++ b/library/block/block_entity/src/main/java/org/quiltmc/qsl/block/entity/api/QuiltBlockEntityTypeBuilder.java
@@ -16,15 +16,17 @@
 
 package org.quiltmc.qsl.block.entity.api;
 
-import com.mojang.datafixers.types.Type;
 import net.minecraft.block.Block;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
-import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
+import org.quiltmc.qsl.block.entity.mixin.accessor.BlockEntityTypeAccessor;
+
+import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Provides a way to build {@link BlockEntityType} with more features than {@link BlockEntityType.BlockEntityFactory}.
@@ -33,9 +35,9 @@ import java.util.List;
  */
 public final class QuiltBlockEntityTypeBuilder<BE extends BlockEntity> {
 	private final BlockEntityType.BlockEntityFactory<? extends BE> factory;
-	private final List<Block> supportedBlocks;
+	private final Set<Block> supportedBlocks;
 
-	private QuiltBlockEntityTypeBuilder(BlockEntityType.BlockEntityFactory<? extends BE> factory, List<Block> supportedBlocks) {
+	private QuiltBlockEntityTypeBuilder(BlockEntityType.BlockEntityFactory<? extends BE> factory, Set<Block> supportedBlocks) {
 		this.factory = factory;
 		this.supportedBlocks = supportedBlocks;
 	}
@@ -48,12 +50,14 @@ public final class QuiltBlockEntityTypeBuilder<BE extends BlockEntity> {
 	 * @param <BE>            the block entity Java type
 	 * @return a new block entity type builder
 	 */
-	public static <BE extends BlockEntity> QuiltBlockEntityTypeBuilder<BE> create(BlockEntityType.BlockEntityFactory<? extends BE> factory,
-			Block... supportedBlocks) {
-		var blocks = new ArrayList<Block>(supportedBlocks.length);
-		Collections.addAll(blocks, supportedBlocks);
-
-		return new QuiltBlockEntityTypeBuilder<>(factory, blocks);
+	public static <BE extends BlockEntity> QuiltBlockEntityTypeBuilder<BE> create(
+		BlockEntityType.BlockEntityFactory<? extends BE> factory, Block... supportedBlocks)
+	{
+		return new QuiltBlockEntityTypeBuilder<>(
+			factory,
+			Arrays.stream(supportedBlocks)
+				.collect(Collectors.toCollection(HashSet::new))
+		);
 	}
 
 	/**
@@ -78,32 +82,12 @@ public final class QuiltBlockEntityTypeBuilder<BE extends BlockEntity> {
 		return this;
 	}
 
-	// FIXME: BlockEntityType$Builder is now a FunctionalInterface named BlockEntityType$BlockEntityFactory
-
-	/**
-	 * Builds the block entity type.
-	 *
-	 * @param type the DFU type, this may be used for datafixers
-	 * @return the built block entity type
-	 * @see #build() build without any care for datafixers
-	 */
-
-
-	 public BlockEntityType<BE> build(@Nullable Type<?> type) {
-		// return BlockEntityType.Builder.<BE>create(this.factory, this.supportedBlocks.toArray(Block[]::new))
-		 return null;
-	}
-
-
-	// FIXME: uhm. what
-
 	/**
 	 * Builds the block entity type.
 	 *
 	 * @return the built block entity type
 	 */
 	public BlockEntityType<BE> build() {
-		// return this.build(null);
-		return null;
+		return BlockEntityTypeAccessor.quilt$create(this.factory, Set.copyOf(this.supportedBlocks));
 	}
 }

--- a/library/block/block_entity/src/main/java/org/quiltmc/qsl/block/entity/mixin/BlockEntityTypeMixin.java
+++ b/library/block/block_entity/src/main/java/org/quiltmc/qsl/block/entity/mixin/BlockEntityTypeMixin.java
@@ -41,20 +41,24 @@ public class BlockEntityTypeMixin implements QuiltBlockEntityType {
 	private Set<Block> blocks;
 
 	@Unique
-	public Set<Block> quilt$getMutableSupportedBlocks() {
-		if (this.blocks instanceof ImmutableSet) {
+	private Set<Block> quilt$getMutableSupportedBlocks() {
+		if (!(this.blocks instanceof HashSet<Block>)) {
 			this.blocks = new HashSet<>(this.blocks);
 		}
 
 		return this.blocks;
 	}
 
+	// from injected interface
+	@SuppressWarnings("AddedMixinMembersNamePattern")
 	@Override
 	public void addSupportedBlock(Block block) {
 		QuiltBlockEntityImpl.INSTANCE.ensureCanModify();
 		this.quilt$getMutableSupportedBlocks().add(block);
 	}
 
+	// from injected interface
+	@SuppressWarnings("AddedMixinMembersNamePattern")
 	@Override
 	public void addSupportedBlocks(Block... blocks) {
 		QuiltBlockEntityImpl.INSTANCE.ensureCanModify();

--- a/library/block/block_entity/src/main/java/org/quiltmc/qsl/block/entity/mixin/accessor/BlockEntityTypeAccessor.java
+++ b/library/block/block_entity/src/main/java/org/quiltmc/qsl/block/entity/mixin/accessor/BlockEntityTypeAccessor.java
@@ -1,0 +1,20 @@
+package org.quiltmc.qsl.block.entity.mixin.accessor;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.BlockEntityType;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import java.util.Set;
+
+@Mixin(BlockEntityType.class)
+public interface BlockEntityTypeAccessor {
+	@Invoker("<init>")
+	static <T extends BlockEntity> BlockEntityType<T> quilt$create(
+		BlockEntityType.BlockEntityFactory<? extends T> factory, Set<Block> blocks
+	) {
+		throw new AssertionError("dummy method body invoked");
+	}
+}

--- a/library/block/block_entity/src/main/resources/quilt_block_entity.mixins.json
+++ b/library/block/block_entity/src/main/resources/quilt_block_entity.mixins.json
@@ -3,7 +3,8 @@
   "package": "org.quiltmc.qsl.block.entity.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "BlockEntityTypeMixin"
+    "BlockEntityTypeMixin",
+    "accessor.BlockEntityTypeAccessor"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/library/block/block_entity/src/testmod/java/org/quiltmc/qsl/block/entity/test/AngyBlock.java
+++ b/library/block/block_entity/src/testmod/java/org/quiltmc/qsl/block/entity/test/AngyBlock.java
@@ -17,9 +17,14 @@
 package org.quiltmc.qsl.block.entity.test;
 
 import com.mojang.serialization.MapCodec;
-import net.minecraft.block.*;
+
 import org.jetbrains.annotations.Nullable;
 
+import net.minecraft.block.AbstractBlock;
+import net.minecraft.block.BlockRenderType;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.BlockWithEntity;
+import net.minecraft.block.MapColor;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.text.Text;
@@ -29,14 +34,14 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 public class AngyBlock extends BlockWithEntity {
-	public AngyBlock(MapColor mapColor) {
-		super(AbstractBlock.Settings.copy(Blocks.STONE).mapColor(mapColor));
+	public AngyBlock(AbstractBlock.Settings settings, MapColor mapColor) {
+		super(settings.mapColor(mapColor));
 	}
 
 	@Override
 	protected ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, BlockHitResult hit) {
 		if (!world.isClient()) {
-			var blockEntity = BlockEntityTypeTest.COLORFUL_BLOCK_ENTITY_TYPE.get(world, pos);
+			final ColorfulBlockEntity blockEntity = BlockEntityTypeTest.COLORFUL_BLOCK_ENTITY_TYPE.get(world, pos);
 
 			if (blockEntity == null) {
 				throw new AssertionError("Missing block entity for angy block at " + pos);

--- a/library/block/block_entity/src/testmod/java/org/quiltmc/qsl/block/entity/test/BlockEntityTypeTest.java
+++ b/library/block/block_entity/src/testmod/java/org/quiltmc/qsl/block/entity/test/BlockEntityTypeTest.java
@@ -19,13 +19,17 @@ package org.quiltmc.qsl.block.entity.test;
 import java.util.ArrayList;
 import java.util.List;
 
+import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
 import net.minecraft.block.MapColor;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
 import net.minecraft.util.Identifier;
 
 import org.quiltmc.loader.api.ModContainer;
@@ -37,42 +41,53 @@ public class BlockEntityTypeTest implements ModInitializer {
 
 	public static final List<AngyBlock> ANGY_BLOCKS = new ArrayList<>();
 
-	public static final AngyBlock INITIAL_ANGY_BLOCK = register(id("initial_angy_block"), new AngyBlock(MapColor.PINK));
-	public static final AngyBlock BUILDER_ADDED_ANGY_BLOCK = register(id("builder_added_angy_block"), new AngyBlock(MapColor.BLUE));
-	public static final AngyBlock BUILDER_MULTI_1_ANGY_BLOCK = register(id("builder_multi_1_angy_block"), new AngyBlock(MapColor.GREEN));
-	public static final AngyBlock BUILDER_MULTI_2_ANGY_BLOCK = register(id("builder_multi_2_angy_block"), new AngyBlock(MapColor.EMERALD));
-	public static final AngyBlock POST_ADDED_ANGY_BLOCK = register(id("post_added_angy_block"), new AngyBlock(MapColor.CYAN));
-	public static final AngyBlock POST_MULTI_1_ANGY_BLOCK = register(id("post_multi_1_angy_block"), new AngyBlock(MapColor.LIME));
-	public static final AngyBlock POST_MULTI_2_ANGY_BLOCK = register(id("post_multi_2_angy_block"), new AngyBlock(MapColor.LIME_TERRACOTTA));
+	public static final AngyBlock INITIAL_ANGY_BLOCK =
+		registerAngy("initial_angy_block", MapColor.PINK);
+	public static final AngyBlock BUILDER_ADDED_ANGY_BLOCK =
+		registerAngy("builder_added_angy_block", MapColor.BLUE);
+	public static final AngyBlock BUILDER_MULTI_1_ANGY_BLOCK =
+		registerAngy("builder_multi_1_angy_block", MapColor.GREEN);
+	public static final AngyBlock BUILDER_MULTI_2_ANGY_BLOCK =
+		registerAngy("builder_multi_2_angy_block", MapColor.EMERALD);
+	public static final AngyBlock POST_ADDED_ANGY_BLOCK =
+		registerAngy("post_added_angy_block", MapColor.CYAN);
+	public static final AngyBlock POST_MULTI_1_ANGY_BLOCK =
+		registerAngy("post_multi_1_angy_block", MapColor.LIME);
+	public static final AngyBlock POST_MULTI_2_ANGY_BLOCK =
+		registerAngy("post_multi_2_angy_block", MapColor.LIME_TERRACOTTA);
 
-	public static final BlockEntityType<ColorfulBlockEntity> COLORFUL_BLOCK_ENTITY_TYPE = QuiltBlockEntityTypeBuilder.create(
-					ColorfulBlockEntity::new, INITIAL_ANGY_BLOCK
-			)
-			.addBlock(BUILDER_ADDED_ANGY_BLOCK)
-			.addBlocks(BUILDER_MULTI_1_ANGY_BLOCK, BUILDER_MULTI_2_ANGY_BLOCK)
-			.build();
+	public static final BlockEntityType<ColorfulBlockEntity> COLORFUL_BLOCK_ENTITY_TYPE = QuiltBlockEntityTypeBuilder
+		.create(ColorfulBlockEntity::new, INITIAL_ANGY_BLOCK)
+		.addBlock(BUILDER_ADDED_ANGY_BLOCK)
+		.addBlocks(BUILDER_MULTI_1_ANGY_BLOCK, BUILDER_MULTI_2_ANGY_BLOCK)
+		.build();
 
 	@Override
 	public void onInitialize(ModContainer mod) {
-		Registry.register(Registries.BLOCK_ENTITY_TYPE, id("colorful"), COLORFUL_BLOCK_ENTITY_TYPE);
+		Registry.register(Registries.BLOCK_ENTITY_TYPE, createId("colorful"), COLORFUL_BLOCK_ENTITY_TYPE);
 
 		COLORFUL_BLOCK_ENTITY_TYPE.addSupportedBlock(POST_ADDED_ANGY_BLOCK);
 		COLORFUL_BLOCK_ENTITY_TYPE.addSupportedBlocks(POST_MULTI_1_ANGY_BLOCK, POST_MULTI_2_ANGY_BLOCK);
 	}
 
-	private static Identifier id(String path) {
+	private static Identifier createId(String path) {
 		return Identifier.of(NAMESPACE, path);
 	}
 
-	private static <B extends Block> B register(Identifier id, B block) {
-		Registry.register(Registries.BLOCK, id, block);
+	private static AngyBlock registerAngy(String path, MapColor mapColor) {
+		final Identifier id = createId(path);
 
-		var item = new BlockItem(block, new Item.Settings());
-		Registry.register(Registries.ITEM, id, item);
+		final RegistryKey<Block> blockKey = RegistryKey.of(RegistryKeys.BLOCK, id);
+		final AngyBlock block = Registry.register(Registries.BLOCK, blockKey, new AngyBlock(
+			AbstractBlock.Settings.copy(Blocks.STONE).key(blockKey),
+			mapColor
+		));
 
-		if (block instanceof AngyBlock angyBlock) {
-			ANGY_BLOCKS.add(angyBlock);
-		}
+		final RegistryKey<Item> itemKey = RegistryKey.of(RegistryKeys.ITEM, id);
+		final var item = new BlockItem(block, new Item.Settings().key(itemKey));
+		Registry.register(Registries.ITEM, itemKey, item);
+
+		ANGY_BLOCKS.add(block);
 
 		return block;
 	}

--- a/library/core/registry/src/main/java/org/quiltmc/qsl/registry/mixin/BlocksMixin.java
+++ b/library/core/registry/src/main/java/org/quiltmc/qsl/registry/mixin/BlocksMixin.java
@@ -19,6 +19,7 @@ package org.quiltmc.qsl.registry.mixin;
 import com.mojang.logging.LogUtils;
 import org.slf4j.Logger;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -30,17 +31,21 @@ import net.minecraft.registry.Registries;
 import org.quiltmc.qsl.registry.api.event.RegistryEvents;
 
 @Mixin(Blocks.class)
-public abstract class BlocksMixin {
-	private static final Logger quilt$LOGGER = LogUtils.getLogger();
+abstract class BlocksMixin {
+	@Unique
+	private static final Logger LOGGER = LogUtils.getLogger();
 
+	// Adds a block registration event that ensures any blocks registered after Block::<clinit> (most modded blocks)
+	// are added to STATE_IDS and their states' caches get initialized.
 	@Inject(method = "<clinit>", at = @At("RETURN"))
-	private static void onInit(CallbackInfo ci) {
+	private static void addLateRegistrationEvent(CallbackInfo ci) {
 		RegistryEvents.getEntryAddEvent(Registries.BLOCK).register(context -> {
 			context.value().getStateManager().getStates().forEach((state) -> {
 				if (Block.STATE_IDS.getRawId(state) == -1) {
 					Block.STATE_IDS.add(state);
+					state.initShapeCache();
 				} else {
-					quilt$LOGGER.warn("BlockState " + state.toString() + " has been added twice!");
+					LOGGER.warn("BlockState {} has been added twice!", state.toString());
 				}
 			});
 		});

--- a/library/entity/entity_events/src/main/java/org/quiltmc/qsl/entity/event/mixin/EntityMixin.java
+++ b/library/entity/entity_events/src/main/java/org/quiltmc/qsl/entity/event/mixin/EntityMixin.java
@@ -17,46 +17,32 @@
 
 package org.quiltmc.qsl.entity.event.mixin;
 
-import java.util.Set;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 
-import com.llamalad7.mixinextras.sugar.Local;
-import net.minecraft.entity.PositionFlag;
 import net.minecraft.world.entity.TeleportTarget;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.world.World;
 
+import org.jetbrains.annotations.Nullable;
 import org.quiltmc.qsl.entity.event.api.EntityWorldChangeEvents;
 
 @Mixin(Entity.class)
-public abstract class EntityMixin {
+abstract class EntityMixin {
 	@Shadow
 	private World world;
 
-	@Inject(method = "teleport(Lnet/minecraft/world/entity/TeleportTarget;)Lnet/minecraft/entity/Entity;", at = @At("RETURN"))
-	private void quilt$afterWorldChanged(TeleportTarget target, CallbackInfoReturnable<Entity> cir) {
-		// Ret will only have an entity if the teleport worked (entity not removed, teleportTarget was valid, entity was successfully created)
-		Entity ret = cir.getReturnValue();
-
-		if (ret != null) {
-			EntityWorldChangeEvents.AFTER_ENTITY_WORLD_CHANGE.invoker().afterWorldChange((Entity) (Object) this, ret, (ServerWorld) this.world, (ServerWorld) ret.getWorld());
+	@ModifyReturnValue(method = "teleportAcrossDimensions", at = @At("RETURN"))
+	private @Nullable Entity quilt$invokeAfterWorldChange(Entity newEntity, ServerWorld world, TeleportTarget target) {
+		if (newEntity != null) {
+			EntityWorldChangeEvents.AFTER_ENTITY_WORLD_CHANGE.invoker()
+				.afterWorldChange((Entity) (Object) this, newEntity, ((ServerWorld) this.world), target.newWorld());
 		}
-	}
 
-	// this targetted method no longer contains a "removal reason" functionality
-	// to account for this, i'm temporarily going to change the injection point to TAIL
-	// until reviewed in the final PRs
-
-	@Inject(
-			method = "teleport(Lnet/minecraft/server/world/ServerWorld;DDDLjava/util/Set;FFZ)Z",
-			at = @At("TAIL"))
-	private void quilt$afterWorldChangedByTeleport(ServerWorld world, double x, double y, double z, Set<PositionFlag> relatives, float yaw, float a, boolean resetCamera, CallbackInfoReturnable<Boolean> cir, @Local(ordinal = 0, argsOnly = true) Entity newEntity) {
-		EntityWorldChangeEvents.AFTER_ENTITY_WORLD_CHANGE.invoker().afterWorldChange((Entity) (Object) this, newEntity, ((ServerWorld) this.world), world);
+		return newEntity;
 	}
 }


### PR DESCRIPTION
- fixes `AFTER_ENTITY_WORLD_CHANGE` (only requires one inject now)
- fixes `QuiltBlockEntityTypeBuilder`; breaks: removes `build(Type)` method because vanilla doesn't have that anymore
- fixes modded blocks: adds `AbstractBlockState::initShapeCache` for states of blocks registered after the `Blocks` class has loaded